### PR TITLE
Rebrand UserAgent to Vigil

### DIFF
--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -1,7 +1,7 @@
 package meta
 
 var (
-	// Version is the compile-time set version of Watchtower
+	// Version is the compile-time set version of Vigil
 	Version = "v0.0.0-unknown"
 
 	// UserAgent is the http client identifier derived from Version
@@ -9,5 +9,5 @@ var (
 )
 
 func init() {
-	UserAgent = "Watchtower/" + Version
+	UserAgent = "Vigil/" + Version
 }

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -1,7 +1,9 @@
 package meta
 
+const Name = "Vigil"
+
 var (
-	// Version is the compile-time set version of Vigil
+	// Version is the compile-time set version
 	Version = "v0.0.0-unknown"
 
 	// UserAgent is the http client identifier derived from Version
@@ -9,5 +11,5 @@ var (
 )
 
 func init() {
-	UserAgent = "Vigil/" + Version
+	UserAgent = Name + "/" + Version
 }

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	shoutrrrSmtp "github.com/containrrr/shoutrrr/pkg/services/smtp"
+	"github.com/containrrr/watchtower/internal/meta"
 	t "github.com/containrrr/watchtower/pkg/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -53,7 +54,7 @@ func newEmailNotifier(c *cobra.Command) t.ConvertibleNotifier {
 func (e *emailTypeNotifier) GetURL(c *cobra.Command) (string, error) {
 	conf := &shoutrrrSmtp.Config{
 		FromAddress: e.From,
-		FromName:    "Vigil",
+		FromName:    meta.Name,
 		ToAddresses: []string{e.To},
 		Port:        uint16(e.Port),
 		Host:        e.Server,

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containrrr/watchtower/internal/meta"
 	ty "github.com/containrrr/watchtower/pkg/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -105,7 +106,7 @@ func GetTitle(hostname string, tag string) string {
 		tb.WriteRune(' ')
 	}
 
-	tb.WriteString("Vigil updates")
+	tb.WriteString(meta.Name + " updates")
 
 	if hostname != "" {
 		tb.WriteString(" on ")

--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/containrrr/watchtower/internal/meta"
 	"github.com/containrrr/watchtower/pkg/registry/helpers"
 	"github.com/containrrr/watchtower/pkg/types"
 	ref "github.com/distribution/reference"
@@ -68,7 +69,7 @@ func GetChallengeRequest(URL url.URL) (*http.Request, error) {
 		return nil, err
 	}
 	req.Header.Set("Accept", "*/*")
-	req.Header.Set("User-Agent", "Vigil (Docker)")
+	req.Header.Set("User-Agent", meta.Name+" (Docker)")
 	return req, nil
 }
 

--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -68,7 +68,7 @@ func GetChallengeRequest(URL url.URL) (*http.Request, error) {
 		return nil, err
 	}
 	req.Header.Set("Accept", "*/*")
-	req.Header.Set("User-Agent", "Watchtower (Docker)")
+	req.Header.Set("User-Agent", "Vigil (Docker)")
 	return req, nil
 }
 

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -3,6 +3,7 @@ package digest_test
 import (
 	"fmt"
 	"github.com/containrrr/watchtower/internal/actions/mocks"
+	"github.com/containrrr/watchtower/internal/meta"
 	"github.com/containrrr/watchtower/pkg/registry/digest"
 	wtTypes "github.com/containrrr/watchtower/pkg/types"
 	. "github.com/onsi/ginkgo/v2"
@@ -107,7 +108,7 @@ var _ = Describe("Digests", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyHeader(http.Header{
-						"User-Agent": []string{"Vigil/v0.0.0-unknown"},
+						"User-Agent": []string{meta.UserAgent},
 					}),
 					ghttp.RespondWith(http.StatusOK, "", http.Header{
 						digest.ContentDigestHeader: []string{

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Digests", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyHeader(http.Header{
-						"User-Agent": []string{"Watchtower/v0.0.0-unknown"},
+						"User-Agent": []string{"Vigil/v0.0.0-unknown"},
 					}),
 					ghttp.RespondWith(http.StatusOK, "", http.Header{
 						digest.ContentDigestHeader: []string{


### PR DESCRIPTION
## Summary
- Update UserAgent string from `Watchtower/<version>` to `Vigil/<version>`
- Update version comment to reference Vigil

## Test plan
- [ ] CI passes (build, test, lint)
- [ ] CodeRabbit review posts automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the application identifier used in HTTP User-Agent to the new product name.
  * Updated notification content and email sender name to use the same product name for titles and SMTP From display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->