### PR TITLE
Fix: propagate error on self-update rename failure

### DIFF
--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -216,7 +216,7 @@ func restartStaleContainer(container types.Container, client container.Client, p
 	if container.IsWatchtower() {
 		if err := client.RenameContainer(container, util.RandName()); err != nil {
 			log.Error(err)
-			return nil
+			return err
 		}
 	}
 


### PR DESCRIPTION
## Summary
- When renaming the current Vigil container before self-update, a rename failure was silently swallowed (`return nil` instead of `return err`)
- The self-update appeared successful while the container was left in an inconsistent state

## Change
One line: `return nil` → `return err` in `restartStaleContainer()`

## Test plan
- [x] `go test ./internal/actions/...` passes
- [ ] CI checks pass

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during container restart operations to properly report and record failures instead of silently treating them as successful outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->