### PR TITLE
Default to rolling restart strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@
 
 - Updated to Docker SDK v27 (fixes "client version too old" errors)
 - Go 1.22+
-- Docker API version bumped from 1.25 to 1.44
+- Docker API version bumped from 1.25 to 1.43
 - New `dev.vigil.*` labels and `VIGIL_*` env vars
+- Rolling restart is now the default (safer — limits blast radius to one container)
 - Fully backward-compatible with existing Watchtower labels and env vars
 
 ## Quick Start
@@ -56,7 +57,7 @@ Vigil supports both its own naming and the legacy Watchtower naming. Vigil names
 | `VIGIL_CLEANUP` | `WATCHTOWER_CLEANUP` | Remove old images after updating |
 | `VIGIL_LABEL_ENABLE` | `WATCHTOWER_LABEL_ENABLE` | Only update containers with enable label |
 | `VIGIL_MONITOR_ONLY` | `WATCHTOWER_MONITOR_ONLY` | Only monitor, don't update |
-| `VIGIL_ROLLING_RESTART` | `WATCHTOWER_ROLLING_RESTART` | Restart containers one at a time |
+| `VIGIL_BATCH_RESTART` | `WATCHTOWER_BATCH_RESTART` | Stop all containers before restarting (default: rolling) |
 | `VIGIL_HTTP_API_UPDATE` | `WATCHTOWER_HTTP_API_UPDATE` | Enable HTTP API for on-demand updates |
 | `VIGIL_NO_PULL` | `WATCHTOWER_NO_PULL` | Do not pull new images |
 | `VIGIL_NO_RESTART` | `WATCHTOWER_NO_RESTART` | Do not restart containers |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,8 +98,11 @@ func PreRun(cmd *cobra.Command, _ []string) {
 	disableContainers, _ = f.GetStringSlice("disable-containers")
 	lifecycleHooks, _ = f.GetBool("enable-lifecycle-hooks")
 	batchRestart, _ = f.GetBool("batch-restart")
-	if rollingRestartSet, _ := f.GetBool("rolling-restart"); rollingRestartSet {
+	if f.Changed("rolling-restart") {
 		log.Warn("--rolling-restart is deprecated and will be removed in v2. Rolling restart is now the default. Remove this flag from your configuration.")
+	}
+	if os.Getenv("WATCHTOWER_ROLLING_RESTART") != "" || os.Getenv("VIGIL_ROLLING_RESTART") != "" {
+		log.Warn("WATCHTOWER_ROLLING_RESTART / VIGIL_ROLLING_RESTART environment variables are deprecated and ignored. Rolling restart is now the default.")
 	}
 	scope, _ = f.GetString("scope")
 	labelPrecedence, _ = f.GetBool("label-take-precedence")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ var (
 	notifier          t.Notifier
 	timeout           time.Duration
 	lifecycleHooks    bool
-	rollingRestart    bool
+	batchRestart      bool
 	scope             string
 	labelPrecedence   bool
 )
@@ -97,7 +97,10 @@ func PreRun(cmd *cobra.Command, _ []string) {
 	enableLabel, _ = f.GetBool("label-enable")
 	disableContainers, _ = f.GetStringSlice("disable-containers")
 	lifecycleHooks, _ = f.GetBool("enable-lifecycle-hooks")
-	rollingRestart, _ = f.GetBool("rolling-restart")
+	batchRestart, _ = f.GetBool("batch-restart")
+	if rollingRestartSet, _ := f.GetBool("rolling-restart"); rollingRestartSet {
+		log.Warn("--rolling-restart is deprecated and will be removed in v2. Rolling restart is now the default. Remove this flag from your configuration.")
+	}
 	scope, _ = f.GetString("scope")
 	labelPrecedence, _ = f.GetBool("label-take-precedence")
 
@@ -153,13 +156,13 @@ func Run(c *cobra.Command, names []string) {
 		os.Exit(0)
 	}
 
-	if rollingRestart && monitorOnly {
+	if !batchRestart && monitorOnly {
 		log.Fatal("Rolling restarts is not compatible with the global monitor only flag")
 	}
 
 	awaitDockerClient()
 
-	if err := actions.CheckForSanity(client, filter, rollingRestart); err != nil {
+	if err := actions.CheckForSanity(client, filter, !batchRestart); err != nil {
 		logNotifyExit(err)
 	}
 
@@ -365,7 +368,7 @@ func runUpdatesWithNotifications(filter t.Filter) *metrics.Metric {
 		Timeout:         timeout,
 		MonitorOnly:     monitorOnly,
 		LifecycleHooks:  lifecycleHooks,
-		RollingRestart:  rollingRestart,
+		RollingRestart:  !batchRestart,
 		LabelPrecedence: labelPrecedence,
 		NoPull:          noPull,
 	}

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -398,7 +398,7 @@ Rolling restart is safer as it limits the blast radius of a failed update to a s
 
 ```text
             Argument: --batch-restart
-Environment Variable: WATCHTOWER_BATCH_RESTART
+Environment Variable: VIGIL_BATCH_RESTART / WATCHTOWER_BATCH_RESTART
                 Type: Boolean
              Default: false
 ```

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -392,16 +392,19 @@ Environment Variable: WATCHTOWER_SCHEDULE
              Default: -
 ```
 
-## Rolling restart
-Restart one image at time instead of stopping and starting all at once.  Useful in conjunction with lifecycle hooks
-to implement zero-downtime deploy.
+## Batch restart
+Stop all containers before restarting, instead of the default rolling restart (one at a time).
+Rolling restart is safer as it limits the blast radius of a failed update to a single container.
 
 ```text
-            Argument: --rolling-restart
-Environment Variable: WATCHTOWER_ROLLING_RESTART
+            Argument: --batch-restart
+Environment Variable: WATCHTOWER_BATCH_RESTART
                 Type: Boolean
              Default: false
 ```
+
+> **Note:** `--rolling-restart` is deprecated. Rolling restart is now the default behavior.
+> Use `--batch-restart` to opt into the old batch behavior.
 
 ## Wait until timeout
 Timeout before the container is forcefully stopped. When set, this option will change the default (`10s`) wait time to the given value. An example: `--stop-timeout 30s` will set the timeout to 30 seconds.

--- a/internal/actions/update_test.go
+++ b/internal/actions/update_test.go
@@ -101,10 +101,18 @@ var _ = Describe("the update action", func() {
 				Expect(client.TestData.TriedToRemoveImageCount).To(Equal(1))
 			})
 		})
-		When("performing a rolling restart update", func() {
+		When("performing a rolling restart update (default)", func() {
 			It("should try to remove the image once", func() {
 				client := CreateMockClient(getCommonTestData(""), false, false)
 				_, err := actions.Update(client, types.UpdateParams{Cleanup: true, RollingRestart: true})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(client.TestData.TriedToRemoveImageCount).To(Equal(1))
+			})
+		})
+		When("performing a batch restart update", func() {
+			It("should try to remove the image once", func() {
+				client := CreateMockClient(getCommonTestData(""), false, false)
+				_, err := actions.Update(client, types.UpdateParams{Cleanup: true, RollingRestart: false})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(client.TestData.TriedToRemoveImageCount).To(Equal(1))
 			})

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -148,10 +148,19 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"Enable the execution of commands triggered by pre- and post-update lifecycle hooks")
 
 	flags.BoolP(
+		"batch-restart",
+		"",
+		envBool("WATCHTOWER_BATCH_RESTART"),
+		"Stop all containers before restarting (default: rolling, one at a time)")
+
+	// Deprecated: rolling-restart is now the default behavior.
+	// Kept as a hidden no-op for backward compatibility.
+	flags.BoolP(
 		"rolling-restart",
 		"",
-		envBool("WATCHTOWER_ROLLING_RESTART"),
-		"Restart containers one at a time")
+		false,
+		"Deprecated: rolling restart is now the default. Use --batch-restart to opt out.")
+	flags.MarkHidden("rolling-restart")
 
 	flags.BoolP(
 		"http-api-update",

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -290,6 +290,7 @@ func TestFlagsArePrecentInDocumentation(t *testing.T) {
 		"notification-gotify-url":       "legacy",
 		"notification-slack-icon-emoji": "legacy",
 		"notification-slack-icon-url":   "legacy",
+		"rolling-restart":               "deprecated, rolling restart is now the default",
 	}
 
 	cmd := new(cobra.Command)


### PR DESCRIPTION
## Summary
- Rolling restart is now the default behavior (stop one → recreate one → next)
- Limits blast radius of a failed recreation to one container instead of all
- New `--batch-restart` / `VIGIL_BATCH_RESTART` flag for the old behavior
- `--rolling-restart` kept as deprecated hidden no-op with warning

## Changes
- `internal/flags/flags.go` — new `batch-restart` flag, deprecated `rolling-restart`
- `cmd/root.go` — flip default, deprecation warning on old flag usage
- `docs/arguments.md` — updated docs
- `README.md` — updated feature list, fixed API version (1.44 → 1.43)
- Tests updated for new default + batch restart path

## Test plan
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [ ] CI checks pass

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --batch-restart option to stop all containers before restarting.

* **Documentation**
  * Clarified Docker API compatibility version and restart behavior.
  * Rolling restart is now the default.
  * Marked the rolling-restart option as deprecated; use batch-restart for prior behavior.

* **Tests**
  * Added test coverage for both rolling (default) and batch restart scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->