### PR TITLE
Rollback container to old image on failed recreation

### DIFF
--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -55,6 +55,11 @@ func (client MockClient) StartContainer(_ t.Container) (t.ContainerID, error) {
 	return "", nil
 }
 
+// StartContainerWithImage is a mock method
+func (client MockClient) StartContainerWithImage(c t.Container, _ string) (t.ContainerID, error) {
+	return client.StartContainer(c)
+}
+
 // RenameContainer is a mock method
 func (client MockClient) RenameContainer(_ t.Container, _ string) error {
 	return nil

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -12,6 +12,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// errRolledBack is returned when a container was rolled back to its previous image.
+// The container is running but was not updated — the old image should not be cleaned up.
+var errRolledBack = errors.New("container rolled back to previous image")
+
 // Update looks at the running Docker containers to see if any of the images
 // used to start those containers have been updated. If a change is detected in
 // any of the images, the associated containers are stopped and restarted with
@@ -105,7 +109,10 @@ func performRollingRestart(containers []types.Container, client container.Client
 				failed[containers[i].ID()] = err
 			} else {
 				if err := restartStaleContainer(containers[i], client, params); err != nil {
-					failed[containers[i].ID()] = err
+					if !errors.Is(err, errRolledBack) {
+						failed[containers[i].ID()] = err
+					}
+					// Skip image cleanup on rollback — the old image is in use
 				} else if containers[i].IsStale() {
 					// Only add (previously) stale containers' images to cleanup
 					cleanupImageIDs[containers[i].ImageID()] = true
@@ -182,7 +189,10 @@ func restartContainersInSortedOrder(containers []types.Container, client contain
 		}
 		if stoppedImages[c.SafeImageID()] {
 			if err := restartStaleContainer(c, client, params); err != nil {
-				failed[c.ID()] = err
+				if !errors.Is(err, errRolledBack) {
+					failed[c.ID()] = err
+				}
+				// Skip image cleanup on rollback — the old image is in use
 			} else if c.IsStale() {
 				// Only add (previously) stale containers' images to cleanup
 				cleanupImageIDs[c.ImageID()] = true
@@ -230,7 +240,7 @@ func restartStaleContainer(container types.Container, client container.Client, p
 				return err
 			}
 			log.Infof("Successfully rolled back %s to previous image", container.Name())
-			return nil
+			return errRolledBack
 		} else if container.ToRestart() && params.LifecycleHooks {
 			lifecycle.ExecutePostUpdateCommand(client, newContainerID)
 		}

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -222,8 +222,15 @@ func restartStaleContainer(container types.Container, client container.Client, p
 
 	if !params.NoRestart {
 		if newContainerID, err := client.StartContainer(container); err != nil {
-			log.Error(err)
-			return err
+			log.Errorf("Failed to start %s with new image: %s", container.Name(), err)
+			oldImageID := container.ContainerInfo().Image
+			log.Infof("Rolling back %s to previous image %s", container.Name(), types.ImageID(oldImageID).ShortID())
+			if _, rollbackErr := client.StartContainerWithImage(container, oldImageID); rollbackErr != nil {
+				log.Errorf("Rollback of %s also failed: %s", container.Name(), rollbackErr)
+				return err
+			}
+			log.Infof("Successfully rolled back %s to previous image", container.Name())
+			return nil
 		} else if container.ToRestart() && params.LifecycleHooks {
 			lifecycle.ExecutePostUpdateCommand(client, newContainerID)
 		}

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -29,6 +29,7 @@ type Client interface {
 	GetContainer(containerID t.ContainerID) (t.Container, error)
 	StopContainer(t.Container, time.Duration) error
 	StartContainer(t.Container) (t.ContainerID, error)
+	StartContainerWithImage(t.Container, string) (t.ContainerID, error)
 	RenameContainer(t.Container, string) error
 	IsContainerStale(t.Container, t.UpdateParams) (stale bool, latestImage t.ImageID, err error)
 	ExecuteCommand(containerID t.ContainerID, command string, timeout int) (SkipUpdate bool, err error)
@@ -249,11 +250,23 @@ func (client dockerClient) GetNetworkConfig(c t.Container) *network.NetworkingCo
 }
 
 func (client dockerClient) StartContainer(c t.Container) (t.ContainerID, error) {
+	return client.startContainer(c, "")
+}
+
+func (client dockerClient) StartContainerWithImage(c t.Container, imageID string) (t.ContainerID, error) {
+	return client.startContainer(c, imageID)
+}
+
+func (client dockerClient) startContainer(c t.Container, imageOverride string) (t.ContainerID, error) {
 	bg := context.Background()
 	config := c.GetCreateConfig()
 	hostConfig := c.GetCreateHostConfig()
 	networkConfig := client.GetNetworkConfig(c)
 	sanitizeContainerConfig(config, client.api.ClientVersion())
+
+	if imageOverride != "" {
+		config.Image = imageOverride
+	}
 
 	// simpleNetworkConfig is a networkConfig with only 1 network.
 	// see: https://github.com/docker/docker/issues/29265

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -289,19 +289,29 @@ func (client dockerClient) startContainer(c t.Container, imageOverride string) (
 		return "", err
 	}
 
+	// cleanup removes the created container if a subsequent step fails,
+	// freeing the name for a rollback attempt.
+	cleanup := func(err error) (t.ContainerID, error) {
+		log.Debugf("Removing partially created container %s due to error: %s", name, err)
+		if rmErr := client.api.ContainerRemove(bg, createdContainer.ID, container.RemoveOptions{Force: true}); rmErr != nil {
+			log.Errorf("Failed to remove partial container %s: %s", name, rmErr)
+		}
+		return "", err
+	}
+
 	if !(hostConfig.NetworkMode.IsHost()) {
 
 		for k := range simpleNetworkConfig.EndpointsConfig {
 			err = client.api.NetworkDisconnect(bg, k, createdContainer.ID, true)
 			if err != nil {
-				return "", err
+				return cleanup(err)
 			}
 		}
 
 		for k, v := range networkConfig.EndpointsConfig {
 			err = client.api.NetworkConnect(bg, k, createdContainer.ID, v)
 			if err != nil {
-				return "", err
+				return cleanup(err)
 			}
 		}
 
@@ -312,7 +322,10 @@ func (client dockerClient) startContainer(c t.Container, imageOverride string) (
 		return createdContainerID, nil
 	}
 
-	return createdContainerID, client.doStartContainer(bg, c, createdContainer)
+	if err := client.doStartContainer(bg, c, createdContainer); err != nil {
+		return cleanup(err)
+	}
+	return createdContainerID, nil
 
 }
 


### PR DESCRIPTION
## Summary
- When container recreation fails after stop/remove, attempt rollback to the previous image
- Old image is still on disk (cleanup happens later), so rollback is always possible
- On successful rollback: container runs on old image, warning logged in notification
- On rollback failure: original error returned, container reported as failed

## Changes
- `pkg/container/client.go` — Add `StartContainerWithImage` to Client interface, refactor `StartContainer` into private helper
- `internal/actions/update.go` — Rollback logic in `restartStaleContainer`
- `internal/actions/mocks/client.go` — Mock for new interface method

## Test plan
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [ ] CI checks pass

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic rollback: if a container fails to start with a new image, the system now attempts to restore the previous image.
  * Rolled-back containers are no longer recorded as failed and their images are not removed during cleanup.
  * Improved restart flow makes rolling updates and image cleanup more resilient and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->