### PR TITLE
Security: enable TLS verification for registry digest checks

### DIFF
--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -1,7 +1,6 @@
 package digest
 
 import (
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -87,7 +86,6 @@ func GetDigest(url string, token string) (string, error) {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr}
 


### PR DESCRIPTION
## Summary
- Remove `InsecureSkipVerify: true` from registry HEAD request transport
- TLS certificates now verified by default, preventing MITM on digest checks
- Inherited from Watchtower — was unconditionally disabled for all registries

## Test plan
- [x] `go test ./pkg/registry/...` — all pass
- [x] `go vet ./...` — clean
- [ ] CI checks pass

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by enforcing standard TLS certificate verification for all HTTPS connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->