### PR TITLE
Fix release: bump Dockerfile build base to golang:1.25-alpine

### DIFF
--- a/dockerfiles/Dockerfile.release
+++ b/dockerfiles/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build
 ARG TARGETOS TARGETARCH VERSION=dev
 WORKDIR /src
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary

The release workflow on PR #13's merge commit ([run 25092309872](https://github.com/Nitroxaddict/vigil/actions/runs/25092309872)) failed with:

```
go: go.mod requires go >= 1.25.0 (running go 1.22.12; GOTOOLCHAIN=local)
```

`go.mod` requires Go 1.25, but I'd put `golang:1.22-alpine` in the new multi-stage `Dockerfile.release`. GHA's `setup-go` quietly auto-upgrades via `GOTOOLCHAIN=auto`, which is why the previous (binary-built-on-runner) flow worked. The official `golang` Docker images set `GOTOOLCHAIN=local` to avoid network fetches at build time, so they can't auto-upgrade — they error out instead.

One-line fix: pin the base image to match `go.mod`.

## Test plan

- [ ] Release workflow succeeds on this branch's merge to `main`
- [ ] `ghcr.io/nitroxaddict/vigil:latest` updates with a multi-arch manifest list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment toolchain to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->