### PR TITLE
fix(schedule): drive schedule loop from wall clock, survive host sleep (ATL-43)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -316,51 +316,89 @@ func writeStartupMessage(c *cobra.Command, sched time.Time, filtering string) {
 	}
 }
 
+// scheduleTickInterval is how often the schedule loop wakes up to compare the
+// wall clock against the next scheduled run. It bounds how late a fire can be
+// after wake from host sleep / Docker VM pause; daily-cadence schedules don't
+// need finer resolution.
+const scheduleTickInterval = 30 * time.Second
+
 func runUpgradesOnSchedule(c *cobra.Command, filter t.Filter, filtering string, lock chan bool) error {
 	if lock == nil {
 		lock = make(chan bool, 1)
 		lock <- true
 	}
 
-	scheduler := cron.New()
-	err := scheduler.AddFunc(
-		scheduleSpec,
-		func() {
-			select {
-			case v := <-lock:
-				defer func() { lock <- v }()
-				metric := runUpdatesWithNotifications(filter)
-				metrics.RegisterScan(metric)
-			default:
-				// Update was skipped
-				metrics.RegisterScan(nil)
-				log.Debug("Skipped another update already running.")
-			}
-
-			nextRuns := scheduler.Entries()
-			if len(nextRuns) > 0 {
-				log.Debug("Scheduled next run: " + nextRuns[0].Next.String())
-			}
-		})
-
+	schedule, err := cron.Parse(scheduleSpec)
 	if err != nil {
 		return err
 	}
 
-	writeStartupMessage(c, scheduler.Entries()[0].Schedule.Next(time.Now()), filtering)
+	firstRun := schedule.Next(time.Now())
+	writeStartupMessage(c, firstRun, filtering)
 
-	scheduler.Start()
+	fire := func(now time.Time) {
+		select {
+		case v := <-lock:
+			defer func() { lock <- v }()
+			metric := runUpdatesWithNotifications(filter)
+			metrics.RegisterScan(metric)
+		default:
+			// Update was skipped
+			metrics.RegisterScan(nil)
+			log.Debug("Skipped another update already running.")
+		}
+		log.Debug("Scheduled next run: " + schedule.Next(now).String())
+	}
 
 	// Graceful shut-down on SIGINT/SIGTERM
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
 	signal.Notify(interrupt, syscall.SIGTERM)
+	stop := make(chan struct{})
+	go func() {
+		<-interrupt
+		close(stop)
+	}()
 
-	<-interrupt
-	scheduler.Stop()
+	ticker := time.NewTicker(scheduleTickInterval)
+	defer ticker.Stop()
+
+	runScheduleLoop(schedule, firstRun, ticker.C, stop, fire)
+
 	log.Info("Waiting for running update to be finished...")
 	<-lock
 	return nil
+}
+
+// runScheduleLoop fires `fire` whenever a tick arrives at or after `next`.
+// Decisions are made on each tick's wall-clock value, never on monotonic time,
+// so the loop survives host sleep / Docker Desktop VM pause: when the runtime
+// resumes after missing one or more windows, the next tick sees now >= next,
+// fires once for the most recent missed window, then advances `next` to the
+// first future window per `schedule`. Multiple windows missed during a single
+// sleep collapse into a single fire — appropriate for a container updater
+// (pull latest now, do not replay history).
+func runScheduleLoop(
+	schedule cron.Schedule,
+	next time.Time,
+	tick <-chan time.Time,
+	stop <-chan struct{},
+	fire func(time.Time),
+) {
+	for {
+		select {
+		case now, ok := <-tick:
+			if !ok {
+				return
+			}
+			if !now.Before(next) {
+				fire(now)
+				next = schedule.Next(now)
+			}
+		case <-stop:
+			return
+		}
+	}
 }
 
 func runUpdatesWithNotifications(filter t.Filter) *metrics.Metric {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/robfig/cron"
+	"github.com/stretchr/testify/assert"
+)
+
+// periodicSchedule is a cron.Schedule that returns t+period for any input t.
+// It lets tests model arbitrary inter-tick deltas without depending on real
+// clocks or cron-spec parsing.
+type periodicSchedule struct {
+	period time.Duration
+}
+
+func (s periodicSchedule) Next(t time.Time) time.Time { return t.Add(s.period) }
+
+func TestRunScheduleLoop(t *testing.T) {
+	base := time.Date(2026, 5, 3, 3, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name      string
+		next      time.Time
+		ticks     []time.Time
+		wantFires int
+	}{
+		{
+			name:      "tick before next does not fire",
+			next:      base,
+			ticks:     []time.Time{base.Add(-time.Second)},
+			wantFires: 0,
+		},
+		{
+			name:      "tick at or after next fires once",
+			next:      base,
+			ticks:     []time.Time{base.Add(time.Second)},
+			wantFires: 1,
+		},
+		{
+			name:      "two ticks in same window fire once",
+			next:      base,
+			ticks:     []time.Time{base.Add(time.Second), base.Add(2 * time.Second)},
+			wantFires: 1,
+		},
+		{
+			name:      "tick after long sleep collapses missed windows into one fire",
+			next:      base,
+			ticks:     []time.Time{base.Add(3 * 24 * time.Hour)},
+			wantFires: 1,
+		},
+		{
+			name:      "tick crossing two separate windows fires twice",
+			next:      base,
+			ticks:     []time.Time{base.Add(time.Second), base.Add(2 * time.Minute)},
+			wantFires: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tick := make(chan time.Time, len(tc.ticks))
+			for _, ts := range tc.ticks {
+				tick <- ts
+			}
+			close(tick)
+
+			fired := 0
+			runScheduleLoop(
+				periodicSchedule{period: time.Minute},
+				tc.next,
+				tick,
+				nil,
+				func(time.Time) { fired++ },
+			)
+
+			assert.Equal(t, tc.wantFires, fired)
+		})
+	}
+}
+
+func TestRunScheduleLoop_StopChannelReturns(t *testing.T) {
+	base := time.Date(2026, 5, 3, 3, 0, 0, 0, time.UTC)
+	tick := make(chan time.Time)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		runScheduleLoop(
+			periodicSchedule{period: time.Minute},
+			base,
+			tick,
+			stop,
+			func(time.Time) {},
+		)
+		close(done)
+	}()
+
+	close(stop)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runScheduleLoop did not return after stop was closed")
+	}
+}
+
+func TestRunScheduleLoop_RealCronScheduleAdvancesPastSlept(t *testing.T) {
+	// "0 0 3 * * *" — daily at 03:00. Mirrors the original bug report.
+	schedule, err := cron.Parse("0 0 3 * * *")
+	assert.NoError(t, err)
+
+	loc := time.UTC
+	scheduledAt := time.Date(2026, 5, 1, 3, 0, 0, 0, loc)
+	wakeAt := time.Date(2026, 5, 3, 10, 30, 0, 0, loc) // 2 days, 7.5 hours past
+
+	tick := make(chan time.Time, 1)
+	tick <- wakeAt
+	close(tick)
+
+	var fireAt time.Time
+	fireCount := 0
+	runScheduleLoop(schedule, scheduledAt, tick, nil, func(now time.Time) {
+		fireCount++
+		fireAt = now
+	})
+
+	assert.Equal(t, 1, fireCount, "should fire exactly once even after multiple missed windows")
+	assert.Equal(t, wakeAt, fireAt, "should fire with the wake-time tick value")
+
+	nextAfterFire := schedule.Next(fireAt)
+	expectedNext := time.Date(2026, 5, 4, 3, 0, 0, 0, loc)
+	assert.Equal(t, expectedNext, nextAfterFire, "next window after fire should be the upcoming 03:00, not a past one")
+}


### PR DESCRIPTION
## Summary

- `runUpgradesOnSchedule` no longer relies on `cron.New()/Start()`, whose internal `time.NewTimer(next - now)` counts **monotonic** time and pauses with the Docker Desktop VM during macOS host sleep — the root cause of ATL-43, where a `--schedule "0 0 3 * * *"` container stayed alive for 3 days but never fired.
- New design: `cron.Parse` still parses the spec and `cron.Schedule.Next` still computes the next window, but firing decisions are made by a 30s wall-clock ticker loop (`runScheduleLoop`). Each tick compares `time.Now()` against `next`; on resume after sleep, the next tick sees `now >= next` and fires once.
- Multiple windows missed during a single sleep collapse into one fire — appropriate for a container updater (pull latest now, do not replay history).

## Files changed

- `cmd/root.go` — replace `runUpgradesOnSchedule` body with parse + ticker; add `runScheduleLoop` helper and `scheduleTickInterval` constant.
- `cmd/root_test.go` — new file: table tests for `runScheduleLoop` (no-fire-before-next, fire-once, debounce within a window, missed-windows-collapse, two-windows-fire-twice, stop-channel returns) plus a real-cron-spec test reproducing the 3-day-suspend scenario from the bug.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./cmd/...` — 7/7 pass
- [x] `go test ./...` — full suite green, no regressions
- [ ] Smoke: build the image, run `vigil --schedule "*/2 * * * * *" --run-once=false ...`, confirm "Session done" lines appear every 2 seconds (left for reviewer if desired)

Resolves ATL-43.