### PR TITLE
fix(update): preserve image tag on rollback so future updates still work (ATL-33)

### DIFF
--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -21,6 +21,12 @@ type TestData struct {
 	NameOfContainerToKeep   string
 	Containers              []t.Container
 	Staleness               map[string]bool
+	// StartContainerError, if non-nil, is returned by MockClient.StartContainer to
+	// drive the rollback branch in actions.restartStaleContainer.
+	StartContainerError error
+	// RollbackImage records the imageID argument passed to StartContainerWithImage.
+	// It stays empty until a rollback fires.
+	RollbackImage string
 }
 
 // TriedToRemoveImage is a test helper function to check whether RemoveImageByID has been called
@@ -52,12 +58,19 @@ func (client MockClient) StopContainer(c t.Container, _ time.Duration) error {
 
 // StartContainer is a mock method
 func (client MockClient) StartContainer(_ t.Container) (t.ContainerID, error) {
+	if client.TestData != nil && client.TestData.StartContainerError != nil {
+		return "", client.TestData.StartContainerError
+	}
 	return "", nil
 }
 
-// StartContainerWithImage is a mock method
-func (client MockClient) StartContainerWithImage(c t.Container, _ string) (t.ContainerID, error) {
-	return client.StartContainer(c)
+// StartContainerWithImage is a mock method. It records the imageID it was called
+// with so tests can assert what was passed to the rollback path.
+func (client MockClient) StartContainerWithImage(_ t.Container, imageID string) (t.ContainerID, error) {
+	if client.TestData != nil {
+		client.TestData.RollbackImage = imageID
+	}
+	return "", nil
 }
 
 // RenameContainer is a mock method

--- a/internal/actions/mocks/container.go
+++ b/internal/actions/mocks/container.go
@@ -79,6 +79,34 @@ func CreateMockContainerWithDigest(id string, name string, image string, created
 	return c
 }
 
+// CreateMockContainerWithRuntimeImage builds a container whose runtime image
+// (ContainerJSONBase.Image, the resolved sha256 digest) differs from the
+// reference recorded in Config.Image (the tag the user actually wrote, e.g.
+// "linuxserver/sonarr:latest"). This is the real shape of any container that
+// has been started from a tagged image.
+func CreateMockContainerWithRuntimeImage(id, name, configImage, runtimeImage string, created time.Time) wt.Container {
+	content := types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{
+			ID:      id,
+			Image:   runtimeImage,
+			Name:    name,
+			Created: created.String(),
+			HostConfig: &dockerContainer.HostConfig{
+				PortBindings: map[nat.Port][]nat.PortBinding{},
+			},
+		},
+		Config: &dockerContainer.Config{
+			Image:        configImage,
+			Labels:       make(map[string]string),
+			ExposedPorts: map[nat.Port]struct{}{},
+		},
+	}
+	return container.NewContainer(
+		&content,
+		CreateMockImageInfo(configImage),
+	)
+}
+
 // CreateMockContainerWithConfig creates a container substitute valid for testing
 func CreateMockContainerWithConfig(id string, name string, image string, running bool, restarting bool, created time.Time, config *dockerContainer.Config) wt.Container {
 	content := types.ContainerJSON{

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -233,9 +233,14 @@ func restartStaleContainer(container types.Container, client container.Client, p
 	if !params.NoRestart {
 		if newContainerID, err := client.StartContainer(container); err != nil {
 			log.Errorf("Failed to start %s with new image: %s", container.Name(), err)
-			oldImageID := container.ContainerInfo().Image
-			log.Infof("Rolling back %s to previous image %s", container.Name(), types.ImageID(oldImageID).ShortID())
-			if _, rollbackErr := client.StartContainerWithImage(container, oldImageID); rollbackErr != nil {
+			// Use the original image reference (e.g. "linuxserver/sonarr:latest"), not
+			// container.ContainerInfo().Image (which is the resolved sha256 digest).
+			// Passing a digest here would write it into Config.Image of the recreated
+			// container, and PullImage would then reject it as a pinned image on the
+			// next update cycle, silently disabling future updates.
+			rollbackImage := container.ImageName()
+			log.Infof("Rolling back %s to previous image %s", container.Name(), rollbackImage)
+			if _, rollbackErr := client.StartContainerWithImage(container, rollbackImage); rollbackErr != nil {
 				log.Errorf("Rollback of %s also failed: %s", container.Name(), rollbackErr)
 				return err
 			}

--- a/internal/actions/update_test.go
+++ b/internal/actions/update_test.go
@@ -1,6 +1,7 @@
 package actions_test
 
 import (
+	"errors"
 	"time"
 
 	"github.com/Nitroxaddict/vigil/internal/actions"
@@ -476,5 +477,39 @@ var _ = Describe("the update action", func() {
 
 		})
 
+	})
+
+	When("a container fails to start with the new image", func() {
+		It("rolls back using the original image reference, not the runtime sha256 digest (ATL-33)", func() {
+			// Real-world shape: Config.Image holds the tag the user wrote;
+			// ContainerJSONBase.Image holds the resolved sha256 digest of the
+			// image the container was actually started from. Passing the digest
+			// to StartContainerWithImage poisons the new container's Config.Image
+			// and PullImage rejects it on the next cycle as a pinned image.
+			const configImage = "linuxserver/sonarr:latest"
+			const runtimeImage = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+			testData := &TestData{
+				Containers: []types.Container{
+					CreateMockContainerWithRuntimeImage(
+						"test-container-rollback",
+						"test-container-rollback",
+						configImage,
+						runtimeImage,
+						time.Now().AddDate(0, 0, -1),
+					),
+				},
+				StartContainerError: errors.New("simulated failure to start with new image"),
+			}
+			client := CreateMockClient(testData, false, false)
+
+			_, err := actions.Update(client, types.UpdateParams{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(client.TestData.RollbackImage).To(Equal(configImage),
+				"rollback must pass the original image reference, not a sha256 digest")
+			Expect(client.TestData.RollbackImage).NotTo(HavePrefix("sha256:"),
+				"sha256 prefix would trip the pinned-image guard in PullImage")
+		})
 	})
 })


### PR DESCRIPTION
## Summary

The new rollback path captured `container.ContainerInfo().Image` (the resolved `sha256:…` digest) and passed it to `StartContainerWithImage`, which writes that override into `Config.Image` of the recreated container. On the next update cycle, `PullImage` reads `ImageName()` (which returns `Config.Image`) and the SHA guard at `pkg/container/client.go:390` rejects it as a pinned image — the rollback succeeded but the container was silently evicted from Vigil's management forever, with no warning.

This switches the rollback to pass `container.ImageName()` (the tag the user actually wrote, e.g. `linuxserver/sonarr:latest`) so `Config.Image` stays a tag and subsequent updates work normally.

Tracks Multica issue ATL-33 / audit finding C1.

## Trade-off

When the *new image itself* is broken, the tag now resolves locally to the broken new digest, so the rollback retry will fail and the container stays dead — but it is no longer silently poisoned. This is the lesser of the two evils per the audit; happy to layer on tag-rebinding later if "actually keep the old image running" becomes a requirement.

## Tests

Adds the regression test called out in the issue (also covers part of S9 / ATL-40):
- Builds a container with `Config.Image = "linuxserver/sonarr:latest"` and `ContainerJSONBase.Image = "sha256:…"`.
- Drives `StartContainer` to error so the rollback branch fires.
- Asserts `StartContainerWithImage` was invoked with the tag, not the digest.

Verified the test fails on the pre-fix code (`sha256:…` vs `linuxserver/sonarr:latest`) and passes after.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages green, 23 specs in `internal/actions`
- [x] New rollback test asserts the tag-not-digest invariant
- [x] New test fails on the pre-fix code (verified by stashing the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)