### PR TITLE
fix(lifecycle): guard against nil-deref on GetContainer error in post-update hook (ATL-37)

### DIFF
--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -83,12 +83,11 @@ func ExecutePreUpdateCommand(client container.Client, container types.Container)
 // ExecutePostUpdateCommand tries to run the post-update lifecycle hook for a single container.
 func ExecutePostUpdateCommand(client container.Client, newContainerID types.ContainerID) {
 	newContainer, err := client.GetContainer(newContainerID)
-	timeout := newContainer.PostUpdateTimeout()
-
 	if err != nil {
 		log.WithField("containerID", newContainerID.ShortID()).Error(err)
 		return
 	}
+	timeout := newContainer.PostUpdateTimeout()
 	clog := log.WithField("container", newContainer.Name())
 
 	command := newContainer.GetLifecyclePostUpdateCommand()

--- a/pkg/lifecycle/lifecycle_suite_test.go
+++ b/pkg/lifecycle/lifecycle_suite_test.go
@@ -1,0 +1,13 @@
+package lifecycle_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLifecycle(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Lifecycle Suite")
+}

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -1,0 +1,50 @@
+package lifecycle_test
+
+import (
+	"errors"
+	"time"
+
+	"github.com/Nitroxaddict/vigil/pkg/container"
+	"github.com/Nitroxaddict/vigil/pkg/lifecycle"
+	t "github.com/Nitroxaddict/vigil/pkg/types"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// errClient is a minimal container.Client implementation whose GetContainer
+// always fails. It mirrors the production behaviour where the Docker SDK
+// returns &container.Container{} (with nil containerInfo) alongside an error.
+type errClient struct {
+	getErr error
+}
+
+func (c errClient) ListContainers(_ t.Filter) ([]t.Container, error) { return nil, nil }
+func (c errClient) GetContainer(_ t.ContainerID) (t.Container, error) {
+	return container.NewContainer(nil, nil), c.getErr
+}
+func (c errClient) StopContainer(_ t.Container, _ time.Duration) error      { return nil }
+func (c errClient) StartContainer(_ t.Container) (t.ContainerID, error)     { return "", nil }
+func (c errClient) StartContainerWithImage(_ t.Container, _ string) (t.ContainerID, error) {
+	return "", nil
+}
+func (c errClient) RenameContainer(_ t.Container, _ string) error { return nil }
+func (c errClient) IsContainerStale(_ t.Container, _ t.UpdateParams) (bool, t.ImageID, error) {
+	return false, "", nil
+}
+func (c errClient) ExecuteCommand(_ t.ContainerID, _ string, _ int) (bool, error) {
+	return false, nil
+}
+func (c errClient) RemoveImageByID(_ t.ImageID) error    { return nil }
+func (c errClient) WarnOnHeadPullFailed(_ t.Container) bool { return false }
+
+var _ = Describe("ExecutePostUpdateCommand", func() {
+	When("GetContainer returns an error", func() {
+		It("does not panic on the empty container returned alongside the error", func() {
+			client := errClient{getErr: errors.New("docker inspect failed")}
+			Expect(func() {
+				lifecycle.ExecutePostUpdateCommand(client, t.ContainerID("abc123"))
+			}).NotTo(Panic())
+		})
+	})
+})


### PR DESCRIPTION
Closes ATL-37.

## Problem

`ExecutePostUpdateCommand` called `newContainer.PostUpdateTimeout()` before
checking the error returned by `client.GetContainer`. On the error path,
`GetContainer` returns `&Container{}` (with `containerInfo == nil`), so
`PostUpdateTimeout()` would nil-deref through `getLabelValueOrEmpty` and crash
the Vigil process mid-update.

## Fix

Reorder so the err-check happens before `PostUpdateTimeout()` is called.
Trivial reorder, no behavior change on the happy path.

## Tests

- New `pkg/lifecycle/lifecycle_suite_test.go` to bootstrap Ginkgo for the
  package.
- New `pkg/lifecycle/lifecycle_test.go` with a regression test that uses an
  in-package mock `container.Client` whose `GetContainer` returns
  `(container.NewContainer(nil, nil), error)`. Asserts `ExecutePostUpdateCommand`
  does not panic.
- Manually verified the test fails on pre-fix code with the expected
  `runtime error: invalid memory address or nil pointer dereference` and
  passes after the fix.
- `go test ./...` is green.