### PR TITLE
fix(flags): route --log-format default through envString so VIGIL_LOG_FORMAT works (ATL-35)

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -96,7 +96,7 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 	flags.StringP(
 		"log-format",
 		"l",
-		viper.GetString("WATCHTOWER_LOG_FORMAT"),
+		envString("WATCHTOWER_LOG_FORMAT"),
 		"Sets what logging format to use for console output. Possible values: Auto, LogFmt, Pretty, JSON")
 
 	flags.BoolP(

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -275,3 +275,27 @@ func TestProcessFlagAliasesInvalidPorcelaineVersion(t *testing.T) {
 	})
 }
 
+// TestLogFormatFlagFromVigilEnvironment verifies that the VIGIL_LOG_FORMAT
+// alias is honored as the default for --log-format, mirroring every other
+// VIGIL_* env var. Must remain the LAST test in this file: the call chain
+// reads VIGIL_LOG_FORMAT via bindEnvWithFallback, which calls
+// viper.Set("WATCHTOWER_LOG_FORMAT", ...) on the global viper instance, and
+// this package has no viper.Reset between tests. Inserting another test
+// after this one would inherit "JSON" as the default and likely break.
+func TestLogFormatFlagFromVigilEnvironment(t *testing.T) {
+	cmd := new(cobra.Command)
+
+	t.Setenv("VIGIL_LOG_FORMAT", "JSON")
+
+	SetDefaults()
+	RegisterDockerFlags(cmd)
+	RegisterSystemFlags(cmd)
+	RegisterNotificationFlags(cmd)
+
+	require.NoError(t, cmd.ParseFlags([]string{}))
+	assert.Equal(t, "JSON", cmd.Flags().Lookup("log-format").Value.String())
+
+	require.NoError(t, SetupLogging(cmd.Flags()))
+	assert.IsType(t, &logrus.JSONFormatter{}, logrus.StandardLogger().Formatter)
+}
+


### PR DESCRIPTION
Closes ATL-35.

## Summary
The `--log-format` flag was the sole outlier reading its default via a direct `viper.GetString("WATCHTOWER_LOG_FORMAT")` call (`internal/flags/flags.go:99`), bypassing the `bindEnvWithFallback` alias chain that every other `VIGIL_*` env var uses. As a result, `WATCHTOWER_LOG_FORMAT` worked but `VIGIL_LOG_FORMAT` was silently ignored — contradicting the README's `VIGIL_*` ↔ `WATCHTOWER_*` contract.

## Change
- `internal/flags/flags.go`: one-line swap to `envString("WATCHTOWER_LOG_FORMAT")` so the `VIGIL_LOG_FORMAT` alias resolves like the rest of the flags.
- `internal/flags/flags_test.go`: append `TestLogFormatFlagFromVigilEnvironment` covering both flag-default propagation and `SetupLogging` selecting `*logrus.JSONFormatter`. The new test is intentionally placed last and carries an inline comment explaining the ordering requirement (the call chain does `viper.Set` on the global viper and the package has no `viper.Reset`).

## Test
- `go test ./internal/flags/...` — pass
- `go test ./...` — pass