### PR TITLE
test: regression coverage for rollback cleanup-skip and digest TLS verify (ATL-40)

### DIFF
--- a/internal/actions/update_test.go
+++ b/internal/actions/update_test.go
@@ -512,4 +512,46 @@ var _ = Describe("the update action", func() {
 				"sha256 prefix would trip the pinned-image guard in PullImage")
 		})
 	})
+
+	When("a rollback fires during the update loop (ATL-40 / S9)", func() {
+		// Guards the errRolledBack cleanup-skip behaviour: when the start of the
+		// new image fails and the container is rolled back to its previous image,
+		// the previous image is still in use and must NOT be passed to cleanupImages.
+		// Asserts TriedToRemoveImageCount == 0 even when params.Cleanup is true.
+		const configImage = "linuxserver/sonarr:latest"
+		const runtimeImage = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+		rollbackTestData := func() *TestData {
+			return &TestData{
+				Containers: []types.Container{
+					CreateMockContainerWithRuntimeImage(
+						"test-container-rollback",
+						"test-container-rollback",
+						configImage,
+						runtimeImage,
+						time.Now().AddDate(0, 0, -1),
+					),
+				},
+				StartContainerError: errors.New("simulated failure to start with new image"),
+			}
+		}
+
+		It("does not clean up the rolled-back image on the batch-restart path", func() {
+			client := CreateMockClient(rollbackTestData(), false, false)
+			_, err := actions.Update(client, types.UpdateParams{Cleanup: true})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.TestData.RollbackImage).To(Equal(configImage))
+			Expect(client.TestData.TriedToRemoveImageCount).To(Equal(0),
+				"image cleanup must be skipped when the container was rolled back — the old image is still in use")
+		})
+
+		It("does not clean up the rolled-back image on the rolling-restart path", func() {
+			client := CreateMockClient(rollbackTestData(), false, false)
+			_, err := actions.Update(client, types.UpdateParams{Cleanup: true, RollingRestart: true})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.TestData.RollbackImage).To(Equal(configImage))
+			Expect(client.TestData.TriedToRemoveImageCount).To(Equal(0),
+				"image cleanup must be skipped when the container was rolled back — the old image is still in use")
+		})
+	})
 })

--- a/pkg/registry/digest/digest_test.go
+++ b/pkg/registry/digest/digest_test.go
@@ -1,6 +1,8 @@
 package digest_test
 
 import (
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"github.com/Nitroxaddict/vigil/internal/actions/mocks"
 	"github.com/Nitroxaddict/vigil/internal/meta"
@@ -121,6 +123,58 @@ var _ = Describe("Digests", func() {
 			Expect(server.ReceivedRequests()).Should(HaveLen(1))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dig).To(Equal(mockDigest))
+		})
+	})
+
+	When("the registry presents an untrusted TLS cert (ATL-40 / S10)", func() {
+		// Guards against any future change that re-introduces InsecureSkipVerify
+		// on the digest HTTP transport. A self-signed cert from ghttp.NewTLSServer
+		// must surface an x509.UnknownAuthorityError rather than being silently accepted.
+		var tlsServer *ghttp.Server
+		BeforeEach(func() {
+			tlsServer = ghttp.NewTLSServer()
+			tlsServer.AppendHandlers(
+				ghttp.RespondWith(http.StatusOK, "", http.Header{
+					digest.ContentDigestHeader: []string{mockDigest},
+				}),
+			)
+		})
+		AfterEach(func() {
+			tlsServer.Close()
+		})
+		It("should refuse to call the registry and surface an unknown-authority error", func() {
+			_, err := digest.GetDigest(tlsServer.URL(), "token")
+			Expect(err).To(HaveOccurred())
+
+			var unknownAuthority x509.UnknownAuthorityError
+			Expect(errors.As(err, &unknownAuthority)).To(BeTrue(),
+				"expected error chain to contain x509.UnknownAuthorityError, got: %v", err)
+			// The handler must not have been reached — the TLS handshake fails first.
+			Expect(tlsServer.ReceivedRequests()).Should(BeEmpty())
+		})
+	})
+
+	When("the registry is reachable over plain HTTP", func() {
+		// Control spec for the TLS-verify test above: confirms GetDigest still
+		// completes against an untrusted/insecure transport, so a failure on the
+		// TLS spec above is unambiguously about cert verification.
+		var server *ghttp.Server
+		BeforeEach(func() {
+			server = ghttp.NewServer()
+			server.AppendHandlers(
+				ghttp.RespondWith(http.StatusOK, "", http.Header{
+					digest.ContentDigestHeader: []string{mockDigest},
+				}),
+			)
+		})
+		AfterEach(func() {
+			server.Close()
+		})
+		It("should return the digest header without TLS errors", func() {
+			dig, err := digest.GetDigest(server.URL(), "token")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dig).To(Equal(mockDigest))
+			Expect(server.ReceivedRequests()).Should(HaveLen(1))
 		})
 	})
 })


### PR DESCRIPTION
Closes ATL-40. Adds the missing test coverage called out in the audit findings S9 and S10.

## What

**`internal/actions/update_test.go`** — adds a `When("a rollback fires during the update loop", ...)` block with two specs:
- batch-restart path (`UpdateParams{Cleanup: true}`)
- rolling-restart path (`UpdateParams{Cleanup: true, RollingRestart: true}`)

Each injects `StartContainerError`, lets the rollback fire, and asserts `TriedToRemoveImageCount == 0`. This guards the `errRolledBack` cleanup-skip contract in both `performRollingRestart` and `restartContainersInSortedOrder`.

**`pkg/registry/digest/digest_test.go`** — adds:
- a TLS spec that points `GetDigest` at `ghttp.NewTLSServer()` (untrusted self-signed cert) and asserts the error chain contains `x509.UnknownAuthorityError` and that no request reached the handler;
- a plain-HTTP control spec for test legibility.

This guards against any future change re-introducing `TLSClientConfig{InsecureSkipVerify: true}` on the digest HTTP transport.

## Why

Both features are security/correctness sensitive (rollback poisoning fixed in ATL-33, TLS verification fixed in `d4c26c8`). Without regression tests a future refactor of either code path could silently revert the fix and pass CI.

## Verification

- `go test ./internal/actions/... ./pkg/registry/digest/...` passes.
- Manually injected the regressions:
  - Adding `cleanupImageIDs[c.ImageID()] = true` to the rollback branches → both rollback specs fail.
  - Setting `TLSClientConfig: &tls.Config{InsecureSkipVerify: true}` on the digest transport → the TLS spec fails (the request now reaches the handler instead of erroring with `x509.UnknownAuthorityError`).

Test-only changes; no production code touched.