### PR TITLE
ci(release): auto-version every code-bearing main merge (ATL-44)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,85 @@ on:
         required: true
         default: 'latest'
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: nitroxaddict/vigil
 
 jobs:
-  build-and-push:
+  auto-version:
+    # Patch-bump and tag every code-bearing merge to main.
+    # Skip dep-bot commits and skip-list-only diffs (.github/**, **/*.md, .gitignore).
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'Update go.mod/go.sum')
     runs-on: ubuntu-latest
-    # Skip if commit is from update-deps bot
-    if: "!contains(github.event.head_commit.message, 'Update go.mod/go.sum')"
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide whether to bump
+        id: gate
+        run: |
+          set -euo pipefail
+          BEFORE="${{ github.event.before }}"
+          if [[ "$BEFORE" == "0000000000000000000000000000000000000000" ]] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "event.before unavailable; comparing against HEAD~1"
+            BEFORE="$(git rev-parse HEAD~1)"
+          fi
+          CHANGED="$(git diff --name-only "$BEFORE" "${{ github.sha }}")"
+          echo "Changed files:"
+          echo "$CHANGED"
+          NON_SKIP="$(printf '%s\n' "$CHANGED" | grep -vE '^(\.github/|.*\.md$|\.gitignore$)' || true)"
+          if [[ -z "$NON_SKIP" ]]; then
+            echo "All changes match skip-list; no version bump."
+            echo "bump=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Non-skip-list changes detected:"
+            echo "$NON_SKIP"
+            echo "bump=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute next patch version
+        if: steps.gate.outputs.bump == 'true'
+        id: bump
+        run: |
+          set -euo pipefail
+          LATEST_TAG="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+          if [[ -z "$LATEST_TAG" ]]; then
+            NEW_TAG="v0.0.1"
+          else
+            VERSION="${LATEST_TAG#v}"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+            NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+          fi
+          echo "Latest tag: ${LATEST_TAG:-<none>}; new tag: $NEW_TAG"
+          echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Tag and release
+        if: steps.gate.outputs.bump == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
+          gh release create "$NEW_TAG" --generate-notes
+
+  build-and-push:
+    # Build and publish images only on tag pushes (created by auto-version or manually) and on manual workflow_dispatch.
+    # The push:main path no longer builds an image directly; latest now moves only when a real release is cut.
+    if: (github.ref_type == 'tag' || github.event_name == 'workflow_dispatch') && !contains(github.event.head_commit.message, 'Update go.mod/go.sum')
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      new_tag: ${{ steps.bump.outputs.new_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,7 +65,8 @@ jobs:
         id: bump
         run: |
           set -euo pipefail
-          LATEST_TAG="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+          # Filter to strict vMAJOR.MINOR.PATCH only — pre-release / suffix tags would crash the patch math under -e.
+          LATEST_TAG="$(git tag --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
           if [[ -z "$LATEST_TAG" ]]; then
             NEW_TAG="v0.0.1"
           else
@@ -88,9 +91,22 @@ jobs:
           gh release create "$NEW_TAG" --generate-notes
 
   build-and-push:
-    # Build and publish images only on tag pushes (created by auto-version or manually) and on manual workflow_dispatch.
-    # The push:main path no longer builds an image directly; latest now moves only when a real release is cut.
-    if: (github.ref_type == 'tag' || github.event_name == 'workflow_dispatch') && !contains(github.event.head_commit.message, 'Update go.mod/go.sum')
+    # GITHUB_TOKEN-pushed tags do NOT trigger a separate workflow run (GitHub Actions policy to prevent loops),
+    # so build-and-push has to be chained off auto-version inside the same workflow run.
+    # Run when:
+    #   - auto-version produced a new tag in this run (chained code-merge path), OR
+    #   - a v* tag was pushed manually (push:tags:v* — auto-version is skipped), OR
+    #   - someone dispatched the workflow manually.
+    # Always skip dep-bot commits.
+    needs: [auto-version]
+    if: |
+      !cancelled() &&
+      !contains(github.event.head_commit.message, 'Update go.mod/go.sum') &&
+      (
+        (needs.auto-version.result == 'success' && needs.auto-version.outputs.new_tag != '') ||
+        github.ref_type == 'tag' ||
+        github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -100,11 +116,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # When auto-version just pushed a new tag in this run, build at that tag for a clean version anchor.
+          ref: ${{ needs.auto-version.outputs.new_tag || github.ref }}
 
       - name: Determine version
         id: version
+        env:
+          AUTO_TAG: ${{ needs.auto-version.outputs.new_tag }}
         run: |
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+          if [[ -n "$AUTO_TAG" ]]; then
+            echo "version=$AUTO_TAG" >> $GITHUB_OUTPUT
+            echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${AUTO_TAG},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref_type }}" == "tag" ]]; then
             echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
             echo "tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Closes ATL-44.

## Summary

Restructure `.github/workflows/release.yml` so every code-bearing merge to `main` auto-bumps the patch version, pushes a `vX.Y.Z` tag, and creates a GitHub Release with auto-generated notes. The image build then runs from the tag-trigger path, so each release publishes its image exactly once.

## What changed

- New `auto-version` job (runs only on `push:main`) with `permissions: contents: write`.
  - Skips dep-bot commits (`Update go.mod/go.sum`).
  - Skips diffs whose every changed file is `.github/**`, `**/*.md`, or `.gitignore` (matches the NoteFlow rule).
  - Falls back to `HEAD~1` when `event.before` is the all-zeros sentinel (initial push) or otherwise unavailable.
  - Bumps the patch of the latest `v*` semver tag, pushes the new tag, runs `gh release create --generate-notes`.
- `build-and-push` is gated to `(github.ref_type == 'tag' || github.event_name == 'workflow_dispatch')`. The push-to-main image build (which only stamped `latest`) is removed — `latest` now moves only when a real release is cut, which is the spec's whole point.
- Workflow-level `concurrency: { group: release-${{ github.ref }}, cancel-in-progress: false }` serializes racing `push:main` runs without cross-interfering with tag-triggered builds (different group).

## Note: this PR is skip-listed

This PR touches only `.github/**`, so it falls under the skip-list and won't auto-bump itself. The next non-skip-list merge produces `v2.0.1`. If an immediate baseline release is desired, push `v2.0.1` manually after merge.

## Manual one-off cleanup (run after merge)

Delete the orphan `2.0.0` image tag from GHCR:

```bash
# Find the version ID for the 2.0.0 image tag
VERSION_ID=$(gh api /user/packages/container/vigil/versions \
  --jq '.[] | select(.metadata.container.tags[]? == "2.0.0") | .id')
echo "Version ID: $VERSION_ID"

# Delete it (keeps the git tag v2.0.0 and the GH release intact)
gh api -X DELETE /user/packages/container/vigil/versions/$VERSION_ID
```

If the package is owned by an org rather than a user, swap `/user/packages/...` for `/orgs/<org>/packages/...`.

## Verification

After merging:

- [ ] Open a docs-only PR (e.g. README typo) → merge → confirm NO new tag/release is created.
- [ ] Open a code PR → merge → confirm patch bump, new tag pushed, GH release created, image published with both `vX.Y.Z` and `latest`.
- [ ] Run the GHCR cleanup snippet above → confirm `vigil:2.0.0` image tag is gone, git tag `v2.0.0` and the GH release v2.0.0 still exist.