### PR TITLE
feat: HTML email template with OCI version labels and XSS-safe rendering

### DIFF
--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -104,12 +104,12 @@ func (client MockClient) ExecuteCommand(_ t.ContainerID, command string, _ int) 
 }
 
 // IsContainerStale is true if not explicitly stated in TestData for the mock client
-func (client MockClient) IsContainerStale(cont t.Container, params t.UpdateParams) (bool, t.ImageID, error) {
+func (client MockClient) IsContainerStale(cont t.Container, params t.UpdateParams) (bool, t.ImageID, map[string]string, error) {
 	stale, found := client.TestData.Staleness[cont.Name()]
 	if !found {
 		stale = true
 	}
-	return stale, "", nil
+	return stale, "", nil, nil
 }
 
 // WarnOnHeadPullFailed is always true for the mock client

--- a/internal/actions/mocks/progress.go
+++ b/internal/actions/mocks/progress.go
@@ -24,14 +24,14 @@ func CreateMockProgressReport(states ...session.State) wt.Report {
 			progress.AddSkipped(c, errors.New("unpossible"))
 		case session.FreshState:
 			c, _ := CreateContainerForProgress(index, 31, "frsh%d")
-			progress.AddScanned(c, c.ImageID())
+			progress.AddScanned(c, c.ImageID(), nil)
 		case session.UpdatedState:
 			c, newImage := CreateContainerForProgress(index, 11, "updt%d")
-			progress.AddScanned(c, newImage)
+			progress.AddScanned(c, newImage, nil)
 			progress.MarkForUpdate(c.ID())
 		case session.FailedState:
 			c, newImage := CreateContainerForProgress(index, 21, "fail%d")
-			progress.AddScanned(c, newImage)
+			progress.AddScanned(c, newImage, nil)
 			failed[c.ID()] = errors.New("accidentally the whole container")
 		}
 

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -37,7 +37,7 @@ func Update(client container.Client, params types.UpdateParams) (types.Report, e
 	staleCheckFailed := 0
 
 	for i, targetContainer := range containers {
-		stale, newestImage, err := client.IsContainerStale(targetContainer, params)
+		stale, newestImage, newestLabels, err := client.IsContainerStale(targetContainer, params)
 		shouldUpdate := stale && !params.NoRestart && !targetContainer.IsMonitorOnly(params)
 		if err == nil && shouldUpdate {
 			// Check to make sure we have all the necessary information for recreating the container
@@ -59,7 +59,7 @@ func Update(client container.Client, params types.UpdateParams) (types.Report, e
 			staleCheckFailed++
 			progress.AddSkipped(targetContainer, err)
 		} else {
-			progress.AddScanned(targetContainer, newestImage)
+			progress.AddScanned(targetContainer, newestImage, newestLabels)
 		}
 		containers[i].SetStale(stale)
 

--- a/internal/flags/email_auto_test.go
+++ b/internal/flags/email_auto_test.go
@@ -1,0 +1,86 @@
+package flags
+
+// Tests for the email notifier auto-default logic in ProcessFlagAliases:
+// when email is the sole legacy notifier, notification-template defaults to
+// email-html (or email-text when --notification-email-plaintext is set) and
+// notification-report is forced to true.
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newEmailFlagsCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	logrus.StandardLogger().ExitFunc = func(_ int) { t.FailNow() }
+	cmd := new(cobra.Command)
+	SetDefaults()
+	RegisterDockerFlags(cmd)
+	RegisterSystemFlags(cmd)
+	RegisterNotificationFlags(cmd)
+	return cmd
+}
+
+func TestEmailAutoDefault_HTMLWhenEmailSoleNotifier(t *testing.T) {
+	cmd := newEmailFlagsCmd(t)
+	require.NoError(t, cmd.ParseFlags([]string{"--notifications", "email"}))
+	ProcessFlagAliases(cmd.Flags())
+
+	tpl, _ := cmd.Flags().GetString("notification-template")
+	assert.Equal(t, "email-html", tpl, "notification-template must default to email-html when email is sole notifier")
+
+	report, _ := cmd.Flags().GetBool("notification-report")
+	assert.True(t, report, "notification-report must be true when email-html is auto-defaulted")
+}
+
+func TestEmailAutoDefault_TextWhenPlaintextFlagSet(t *testing.T) {
+	cmd := newEmailFlagsCmd(t)
+	require.NoError(t, cmd.ParseFlags([]string{
+		"--notifications", "email",
+		"--notification-email-plaintext",
+	}))
+	ProcessFlagAliases(cmd.Flags())
+
+	tpl, _ := cmd.Flags().GetString("notification-template")
+	assert.Equal(t, "email-text", tpl, "notification-template must be email-text when --notification-email-plaintext is set")
+}
+
+func TestEmailAutoDefault_ExplicitTemplateNotOverridden(t *testing.T) {
+	cmd := newEmailFlagsCmd(t)
+	require.NoError(t, cmd.ParseFlags([]string{
+		"--notifications", "email",
+		"--notification-template", "default",
+	}))
+	ProcessFlagAliases(cmd.Flags())
+
+	tpl, _ := cmd.Flags().GetString("notification-template")
+	assert.Equal(t, "default", tpl, "explicit --notification-template must not be overridden")
+}
+
+func TestEmailAutoDefault_NotFiredWhenMultipleNotifiers(t *testing.T) {
+	cmd := newEmailFlagsCmd(t)
+	require.NoError(t, cmd.ParseFlags([]string{
+		"--notifications", "email,slack",
+	}))
+	ProcessFlagAliases(cmd.Flags())
+
+	tpl, _ := cmd.Flags().GetString("notification-template")
+	assert.NotEqual(t, "email-html", tpl, "auto-default must not fire when multiple notifiers are configured")
+}
+
+func TestEmailAutoDefault_NotFiredWhenNotificationURLPresent(t *testing.T) {
+	cmd := newEmailFlagsCmd(t)
+	require.NoError(t, cmd.ParseFlags([]string{
+		"--notifications", "email",
+		"--notification-url", "slack://hook:tokenA-tokenB-tokenC@webhook",
+	}))
+	ProcessFlagAliases(cmd.Flags())
+
+	tpl, _ := cmd.Flags().GetString("notification-template")
+	assert.NotEqual(t, "email-html", tpl,
+		"auto-default must not fire when --notification-url entries are present (HTML would leak into other notifiers)")
+}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -384,6 +384,11 @@ verification on HTTP→HTTPS redirects.`)
 		envBool("WATCHTOWER_NOTIFICATION_REPORT"),
 		"Use the session report as the notification template data")
 
+	flags.Bool(
+		"notification-email-plaintext",
+		envBool("WATCHTOWER_NOTIFICATION_EMAIL_PLAINTEXT"),
+		"Use plain-text email format (email-text) instead of HTML (email-html) when email is the sole notifier")
+
 	flags.StringP(
 		"notification-title-tag",
 		"",
@@ -634,6 +639,25 @@ func ProcessFlagAliases(flags *pflag.FlagSet) {
 		setFlagIfDefault(flags, `notification-report`, `true`)
 		tpl := fmt.Sprintf(`porcelain.%s.summary-no-log`, porcelain)
 		setFlagIfDefault(flags, `notification-template`, tpl)
+	}
+
+	// Auto-default to email-html (or email-text) when the legacy email notifier
+	// is the *sole* configured notifier and no shoutrrr notification-url entries
+	// are present. This is the only path where it is safe to switch the shared
+	// template to an HTML-specific one without leaking raw HTML into other
+	// services (Slack, Gotify, …).
+	notifTypes, _ := flags.GetStringSlice("notifications")
+	notifURLs, _ := flags.GetStringArray("notification-url")
+	if len(notifTypes) == 1 && notifTypes[0] == "email" && len(notifURLs) == 0 {
+		// notification-report must be true so that .Report/.Time are populated;
+		// legacy-template mode passes only []*log.Entry and would crash.
+		setFlagIfDefault(flags, "notification-report", "true")
+		plaintext, _ := flags.GetBool("notification-email-plaintext")
+		if plaintext {
+			setFlagIfDefault(flags, "notification-template", "email-text")
+		} else {
+			setFlagIfDefault(flags, "notification-template", "email-html")
+		}
 	}
 
 	scheduleChanged := flags.Changed(`schedule`)

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -31,7 +31,7 @@ type Client interface {
 	StartContainer(t.Container) (t.ContainerID, error)
 	StartContainerWithImage(t.Container, string) (t.ContainerID, error)
 	RenameContainer(t.Container, string) error
-	IsContainerStale(t.Container, t.UpdateParams) (stale bool, latestImage t.ImageID, err error)
+	IsContainerStale(t.Container, t.UpdateParams) (stale bool, latestImage t.ImageID, latestLabels map[string]string, err error)
 	ExecuteCommand(containerID t.ContainerID, command string, timeout int) (SkipUpdate bool, err error)
 	RemoveImageByID(t.ImageID) error
 	WarnOnHeadPullFailed(container t.Container) bool
@@ -345,35 +345,40 @@ func (client dockerClient) RenameContainer(c t.Container, newName string) error 
 	return client.api.ContainerRename(bg, string(c.ID()), newName)
 }
 
-func (client dockerClient) IsContainerStale(container t.Container, params t.UpdateParams) (stale bool, latestImage t.ImageID, err error) {
+func (client dockerClient) IsContainerStale(container t.Container, params t.UpdateParams) (stale bool, latestImage t.ImageID, latestLabels map[string]string, err error) {
 	ctx := context.Background()
 
 	if container.IsNoPull(params) {
 		log.Debugf("Skipping image pull.")
 	} else if err := client.PullImage(ctx, container); err != nil {
-		return false, container.SafeImageID(), err
+		return false, container.SafeImageID(), nil, err
 	}
 
 	return client.HasNewImage(ctx, container)
 }
 
-func (client dockerClient) HasNewImage(ctx context.Context, container t.Container) (hasNew bool, latestImage t.ImageID, err error) {
+func (client dockerClient) HasNewImage(ctx context.Context, container t.Container) (hasNew bool, latestImage t.ImageID, latestLabels map[string]string, err error) {
 	currentImageID := t.ImageID(container.ContainerInfo().ContainerJSONBase.Image)
 	imageName := container.ImageName()
 
 	newImageInfo, _, err := client.api.ImageInspectWithRaw(ctx, imageName)
 	if err != nil {
-		return false, currentImageID, err
+		return false, currentImageID, nil, err
 	}
 
 	newImageID := t.ImageID(newImageInfo.ID)
 	if newImageID == currentImageID {
 		log.Debugf("No new images found for %s", container.Name())
-		return false, currentImageID, nil
+		return false, currentImageID, nil, nil
+	}
+
+	var labels map[string]string
+	if newImageInfo.Config != nil {
+		labels = newImageInfo.Config.Labels
 	}
 
 	log.Infof("Found new %s image (%s)", imageName, newImageID.ShortID())
-	return true, newImageID, nil
+	return true, newImageID, labels, nil
 }
 
 // PullImage pulls the latest image for the supplied container, optionally skipping if it's digest can be confirmed

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -29,8 +29,8 @@ func (c errClient) StartContainerWithImage(_ t.Container, _ string) (t.Container
 	return "", nil
 }
 func (c errClient) RenameContainer(_ t.Container, _ string) error { return nil }
-func (c errClient) IsContainerStale(_ t.Container, _ t.UpdateParams) (bool, t.ImageID, error) {
-	return false, "", nil
+func (c errClient) IsContainerStale(_ t.Container, _ t.UpdateParams) (bool, t.ImageID, map[string]string, error) {
+	return false, "", nil, nil
 }
 func (c errClient) ExecuteCommand(_ t.ContainerID, _ string, _ int) (bool, error) {
 	return false, nil

--- a/pkg/notifications/common_templates.go
+++ b/pkg/notifications/common_templates.go
@@ -37,4 +37,111 @@ var commonTemplates = map[string]string{
 {{- end -}}`,
 
 	`json.v1`: `{{ . | ToJSON }}`,
+
+	// email-html is rendered via html/template (context-aware HTML escaping) to
+	// prevent XSS from attacker-controlled container/image metadata. Do not
+	// switch this to text/template.
+	`email-html`: `{{- if .Report -}}
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#e5e7eb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+<div style="max-width:560px;margin:0 auto;padding:24px 16px 36px">
+<div style="background:#0f172a;border-radius:8px 8px 0 0;padding:16px 20px 14px">
+<div style="font-size:9px;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:#475569;margin-bottom:6px">VIGIL</div>
+<div style="display:flex;align-items:center;justify-content:space-between">
+<span style="font-size:18px;font-weight:700;color:#f1f5f9;letter-spacing:-0.3px">{{.Title}}</span>
+{{- if .Report.Failed}}<span style="color:#fca5a5;background:#450a0a;font-size:11px;font-weight:600;padding:3px 10px;border-radius:20px">{{len .Report.Failed}} failed</span>{{- end}}
+</div>
+<div style="font-size:11px;color:#475569">{{.Time.Format "Monday, 2 January 2006 · 15:04 MST"}}</div>
+</div>
+<div style="height:16px"></div>
+{{- if or .Report.Failed .Report.Updated .Report.Stale}}
+{{- if .Report.Failed}}
+<div style="font-size:9px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:#f87171;padding:0 2px 7px">FAILED</div>
+<div style="background:#ffffff;border-radius:6px;overflow:hidden;margin-bottom:16px;box-shadow:0 1px 3px rgba(0,0,0,0.07)">
+{{- range $i,$c := .Report.Failed}}
+<div style="border-left:3px solid #ef4444;padding:10px 14px{{if $i}};border-top:1px solid #f3f4f6{{end}}">
+<div style="display:flex;justify-content:space-between;align-items:baseline">
+<span style="font-size:13px;font-weight:600;color:#111827">{{$c.Name}}</span>
+<span style="font-family:monospace;font-size:10px;background:#f3f4f6;color:#6b7280;padding:1px 5px;border-radius:3px">{{$c.CurrentImageID.ShortID}}</span>
+</div>
+<div style="font-size:10px;color:#9ca3af;margin-top:1px">{{$c.ImageName}}</div>
+{{- if $c.Error}}<div style="font-size:11px;color:#ef4444;background:#fef2f2;padding:5px 8px;border-radius:4px;margin-top:6px;font-family:monospace">{{$c.Error}}</div>{{end}}
+</div>
+{{- end}}
+</div>
+{{- end}}
+{{- if .Report.Updated}}
+<div style="font-size:9px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:#9ca3af;padding:0 2px 7px">UPDATED</div>
+<div style="background:#ffffff;border-radius:6px;overflow:hidden;margin-bottom:16px;box-shadow:0 1px 3px rgba(0,0,0,0.07)">
+{{- range $i,$c := .Report.Updated}}
+<div style="border-left:3px solid #10b981;padding:9px 14px{{if $i}};border-top:1px solid #f3f4f6{{end}}">
+<div style="display:flex;justify-content:space-between;align-items:baseline">
+<span style="font-size:13px;font-weight:600;color:#111827">{{$c.Name}}</span>
+<span style="font-family:monospace;font-size:10px"><span style="background:#f3f4f6;color:#6b7280;padding:1px 5px;border-radius:3px">{{$c.CurrentImageID.ShortID}}</span><span style="color:#d1d5db;margin:0 4px">&#8594;</span><span style="background:#ecfdf5;color:#059669;padding:1px 5px;border-radius:3px">{{versionOrID $c}}</span></span>
+</div>
+<div style="font-size:10px;color:#9ca3af;margin-top:1px">{{$c.ImageName}}</div>
+</div>
+{{- end}}
+</div>
+{{- end}}
+{{- if .Report.Stale}}
+<div style="display:flex;align-items:center;gap:8px;padding:0 2px 7px"><span style="font-size:9px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:#9ca3af">UPDATE AVAILABLE</span><span style="font-size:9px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;color:#6b7280;background:#e5e7eb;padding:1px 6px;border-radius:10px">monitor only</span></div>
+<div style="background:#ffffff;border-radius:6px;overflow:hidden;margin-bottom:24px;box-shadow:0 1px 3px rgba(0,0,0,0.07)">
+{{- range $i,$c := .Report.Stale}}
+<div style="border-left:3px solid #e5e7eb;padding:8px 14px{{if $i}};border-top:1px solid #f3f4f6{{end}}">
+<div style="display:flex;align-items:center;justify-content:space-between">
+<span style="font-size:12px;color:#6b7280">{{$c.ImageName}}</span>
+<span style="font-family:monospace;font-size:10px;color:#9ca3af;background:#f9fafb;padding:1px 5px;border-radius:3px">{{versionOrID $c}}</span>
+</div>
+</div>
+{{- end}}
+</div>
+{{- end}}
+{{- else}}
+<div style="background:#ffffff;border-radius:6px;overflow:hidden;margin-bottom:24px;box-shadow:0 1px 3px rgba(0,0,0,0.07)">
+<div style="border-left:3px solid #10b981;padding:12px 14px">
+<div style="font-size:13px;font-weight:600;color:#111827">&#10003; Everything is up to date</div>
+<div style="font-size:10px;color:#9ca3af;margin-top:2px">No updates, failures, or pending changes</div>
+</div>
+</div>
+{{- end}}
+<div style="text-align:center;font-size:10px;color:#9ca3af">Vigil &#183; github.com/Nitroxaddict/vigil</div>
+</div>
+</body>
+</html>
+{{- else -}}
+{{range .Entries}}{{.Message}}
+{{end -}}
+{{- end -}}`,
+
+	`email-text`: `{{- if .Report -}}
+{{.Title}}
+{{- if .Report.Failed}}
+
+FAILED ({{len .Report.Failed}})
+{{range .Report.Failed -}}
+{{.Name | sanitizeField}} | {{.ImageName | sanitizeField}} | {{.Error | sanitizeField}}
+{{end}}{{- end -}}
+{{- if .Report.Updated}}
+
+UPDATED ({{len .Report.Updated}})
+{{range .Report.Updated -}}
+{{.Name | sanitizeField}} | {{.ImageName | sanitizeField}} | {{.CurrentImageID.ShortID}} -> {{versionOrID .}}
+{{end}}{{- end -}}
+{{- if .Report.Stale}}
+
+UPDATE AVAILABLE -- MONITOR ONLY ({{len .Report.Stale}})
+{{range .Report.Stale -}}
+{{.ImageName | sanitizeField}} | {{versionOrID .}}
+{{end}}{{- end}}
+{{- if not (or .Report.Failed .Report.Updated .Report.Stale)}}
+
+Everything is up to date. Nothing to report.
+{{- end}}
+{{- else -}}
+{{range .Entries}}{{.Message}}
+{{end -}}
+{{- end -}}`,
 }

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -52,6 +52,12 @@ func newEmailNotifier(c *cobra.Command) t.ConvertibleNotifier {
 }
 
 func (e *emailTypeNotifier) GetURL(c *cobra.Command) (string, error) {
+	// UseHTML derives from the resolved notification-template flag so that an
+	// explicit --notification-template=email-text override is respected even
+	// when the auto-default would have chosen email-html.
+	resolvedTemplate, _ := c.Flags().GetString("notification-template")
+	useHTML := resolvedTemplate == "email-html"
+
 	conf := &shoutrrrSmtp.Config{
 		FromAddress: e.From,
 		FromName:    meta.Name,
@@ -61,7 +67,7 @@ func (e *emailTypeNotifier) GetURL(c *cobra.Command) (string, error) {
 		Username:    e.User,
 		Password:    e.Password,
 		UseStartTLS: true,
-		UseHTML:     false,
+		UseHTML:     useHTML,
 		Encryption:  shoutrrrSmtp.EncMethods.Auto,
 		Auth:        shoutrrrSmtp.AuthTypes.None,
 		ClientHost:  "localhost",

--- a/pkg/notifications/email_html_test.go
+++ b/pkg/notifications/email_html_test.go
@@ -1,0 +1,404 @@
+package notifications
+
+// White-box tests for the email-html and email-text templates.
+// Tests live in the notifications package so they can call unexported helpers
+// such as getShoutrrrHTMLTemplate and getShoutrrrTemplate.
+
+import (
+	"bytes"
+	"strings"
+	"time"
+
+	"github.com/Nitroxaddict/vigil/internal/actions/mocks"
+	s "github.com/Nitroxaddict/vigil/pkg/session"
+	t "github.com/Nitroxaddict/vigil/pkg/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+// --- helpers ----------------------------------------------------------------
+
+// mockReport wraps slices of ContainerReports so tests can build arbitrary
+// report states without going through the progress machinery.
+type mockReport struct {
+	updated []t.ContainerReport
+	failed  []t.ContainerReport
+	stale   []t.ContainerReport
+	fresh   []t.ContainerReport
+	skipped []t.ContainerReport
+	scanned []t.ContainerReport
+}
+
+func (r *mockReport) Updated() []t.ContainerReport { return r.updated }
+func (r *mockReport) Failed() []t.ContainerReport  { return r.failed }
+func (r *mockReport) Stale() []t.ContainerReport   { return r.stale }
+func (r *mockReport) Fresh() []t.ContainerReport   { return r.fresh }
+func (r *mockReport) Skipped() []t.ContainerReport { return r.skipped }
+func (r *mockReport) Scanned() []t.ContainerReport { return r.scanned }
+func (r *mockReport) All() []t.ContainerReport {
+	all := make([]t.ContainerReport, 0)
+	all = append(all, r.updated...)
+	all = append(all, r.failed...)
+	all = append(all, r.stale...)
+	all = append(all, r.fresh...)
+	all = append(all, r.skipped...)
+	return all
+}
+
+// injectableStatus is a ContainerReport whose fields are fully controllable —
+// used to inject attacker-controlled values into template rendering tests.
+type injectableStatus struct {
+	name           string
+	imageName      string
+	currentImageID t.ImageID
+	latestImageID  t.ImageID
+	latestVersion  string
+	errStr         string
+}
+
+func (c *injectableStatus) ID() t.ContainerID           { return "id-test" }
+func (c *injectableStatus) Name() string                 { return c.name }
+func (c *injectableStatus) CurrentImageID() t.ImageID    { return c.currentImageID }
+func (c *injectableStatus) LatestImageID() t.ImageID     { return c.latestImageID }
+func (c *injectableStatus) LatestImageVersion() string   { return c.latestVersion }
+func (c *injectableStatus) ImageName() string            { return c.imageName }
+func (c *injectableStatus) Error() string                { return c.errStr }
+func (c *injectableStatus) State() string                { return "Updated" }
+
+func renderHTMLTemplate(data Data) (string, error) {
+	htmlTpl, err := getShoutrrrHTMLTemplate()
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := htmlTpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func renderTextTemplate(data Data) (string, error) {
+	tpl, err := getShoutrrrTemplate("email-text", false)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := tpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func staticData() StaticData {
+	return StaticData{
+		Title: "Vigil updates on atlantis",
+		Host:  "atlantis",
+		Time:  time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+// --- test suite -------------------------------------------------------------
+
+var _ = Describe("email-html template", func() {
+
+	Describe("HTML escaping (XSS prevention)", func() {
+		// Security-critical: container names, image names, OCI version labels,
+		// and error strings are attacker-influenceable. html/template must escape
+		// them so that no attacker-controlled string executes as HTML.
+		//
+		// Correct html/template escaping:
+		//   "<script>alert(1)</script>"  → "&lt;script&gt;alert(1)&lt;/script&gt;"
+		//   "\">" + "<img…"              → "&#34;&gt;&lt;img…"
+		//
+		// We verify that raw opening angle brackets do NOT appear where
+		// attacker-controlled content is rendered — the angle bracket is
+		// precisely what makes a tag boundary.
+
+		It("escapes script tag in container name (failed section)", func() {
+			cs := &injectableStatus{
+				name:           `<script>alert(1)</script>`,
+				imageName:      "image:latest",
+				currentImageID: t.ImageID("sha256:aaaa"),
+				latestImageID:  t.ImageID("sha256:bbbb"),
+				errStr:         "restart failed",
+			}
+			report := &mockReport{failed: []t.ContainerReport{cs}}
+			data := Data{StaticData: staticData(), Report: report}
+
+			out, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			// The raw <script tag must not appear — it must be escaped to &lt;script
+			Expect(out).NotTo(ContainSubstring("<script>"),
+				"raw <script> tag must not appear in HTML output")
+			Expect(out).To(ContainSubstring("&lt;script&gt;"),
+				"script tag must be HTML-escaped in output")
+		})
+
+		It("escapes img-onerror payload in container name (failed section)", func() {
+			cs := &injectableStatus{
+				name:           `"><img src=x onerror=alert(1)>`,
+				imageName:      "image:latest",
+				currentImageID: t.ImageID("sha256:aaaa"),
+				latestImageID:  t.ImageID("sha256:bbbb"),
+				errStr:         "restart failed",
+			}
+			report := &mockReport{failed: []t.ContainerReport{cs}}
+			data := Data{StaticData: staticData(), Report: report}
+
+			out, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			// The literal string "<img" must not appear as a raw tag start
+			Expect(out).NotTo(ContainSubstring("<img "),
+				"raw <img tag must not appear; must be escaped to &lt;img")
+			Expect(out).To(ContainSubstring("&lt;img"),
+				"img tag open must be escaped in output")
+		})
+
+		It("escapes XSS payloads in image name (updated section)", func() {
+			cs := &injectableStatus{
+				name:           "mycontainer",
+				imageName:      `<script>alert(1)</script>`,
+				currentImageID: t.ImageID("sha256:aaaa"),
+				latestImageID:  t.ImageID("sha256:bbbb"),
+			}
+			report := &mockReport{updated: []t.ContainerReport{cs}}
+			data := Data{StaticData: staticData(), Report: report}
+
+			out, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).NotTo(ContainSubstring("<script>"))
+			Expect(out).To(ContainSubstring("&lt;script&gt;"))
+		})
+
+		It("escapes script tag in OCI version label (versionOrID, updated section)", func() {
+			cs := &injectableStatus{
+				name:           "mycontainer",
+				imageName:      "image:latest",
+				currentImageID: t.ImageID("sha256:aaaa"),
+				latestImageID:  t.ImageID("sha256:bbbb"),
+				latestVersion:  `<script>alert(1)</script>`,
+			}
+			report := &mockReport{updated: []t.ContainerReport{cs}}
+			data := Data{StaticData: staticData(), Report: report}
+
+			out, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).NotTo(ContainSubstring("<script>"),
+				"script tag in OCI version label must be escaped")
+			Expect(out).To(ContainSubstring("&lt;script&gt;"))
+		})
+
+		It("escapes img-onerror payload in OCI version label (versionOrID, updated section)", func() {
+			cs := &injectableStatus{
+				name:           "mycontainer",
+				imageName:      "image:latest",
+				currentImageID: t.ImageID("sha256:aaaa"),
+				latestImageID:  t.ImageID("sha256:bbbb"),
+				latestVersion:  `"><img src=x onerror=alert(1)>`,
+			}
+			report := &mockReport{updated: []t.ContainerReport{cs}}
+			data := Data{StaticData: staticData(), Report: report}
+
+			out, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			// Raw <img must not appear in output
+			Expect(out).NotTo(ContainSubstring("<img "),
+				"raw <img tag in OCI version label must be escaped")
+		})
+
+		It("escapes XSS payload in error string (failed section)", func() {
+			cs := &injectableStatus{
+				name:           "mycontainer",
+				imageName:      "image:latest",
+				currentImageID: t.ImageID("sha256:aaaa"),
+				latestImageID:  t.ImageID("sha256:bbbb"),
+				errStr:         `<script>alert(1)</script>`,
+			}
+			report := &mockReport{failed: []t.ContainerReport{cs}}
+			data := Data{StaticData: staticData(), Report: report}
+
+			out, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).NotTo(ContainSubstring("<script>"))
+			Expect(out).To(ContainSubstring("&lt;script&gt;"))
+		})
+
+		It("escapes XSS payloads in OCI version label (stale section)", func() {
+			cs := &injectableStatus{
+				name:           "mycontainer",
+				imageName:      "image:latest",
+				currentImageID: t.ImageID("sha256:aaaa"),
+				latestImageID:  t.ImageID("sha256:bbbb"),
+				latestVersion:  `<script>alert(1)</script>`,
+			}
+			report := &mockReport{stale: []t.ContainerReport{cs}}
+			data := Data{StaticData: staticData(), Report: report}
+
+			out, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).NotTo(ContainSubstring("<script>"))
+		})
+	})
+
+	Describe("nil / missing label safety", func() {
+		It("falls back to ShortID() when LatestImageVersion() is empty, no panic", func() {
+			cs := &injectableStatus{
+				name:           "mycontainer",
+				imageName:      "image:latest",
+				currentImageID: t.ImageID("sha256:aaaa000000000000"),
+				latestImageID:  t.ImageID("sha256:bbbb000000000000"),
+				latestVersion:  "", // no version label
+			}
+			report := &mockReport{updated: []t.ContainerReport{cs}}
+			data := Data{StaticData: staticData(), Report: report}
+
+			Expect(func() {
+				out, err := renderHTMLTemplate(data)
+				Expect(err).NotTo(HaveOccurred())
+				// ShortID of sha256:bbbb000000000000 is first 12 hex chars after "sha256:"
+				Expect(out).To(ContainSubstring("bbbb00000000"))
+			}).NotTo(Panic())
+		})
+
+		It("falls back to ShortID() in email-text when LatestImageVersion() is empty", func() {
+			cs := &injectableStatus{
+				name:           "mycontainer",
+				imageName:      "image:latest",
+				currentImageID: t.ImageID("sha256:aaaa000000000000"),
+				latestImageID:  t.ImageID("sha256:bbbb000000000000"),
+				latestVersion:  "",
+			}
+			report := &mockReport{updated: []t.ContainerReport{cs}}
+			data := Data{StaticData: staticData(), Report: report}
+
+			out, err := renderTextTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring("bbbb00000000"))
+		})
+	})
+
+	Describe("'N failed' pill", func() {
+		It("is absent when there are no failures", func() {
+			report := mocks.CreateMockProgressReport(s.UpdatedState)
+			data := Data{StaticData: staticData(), Report: report}
+
+			out, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).NotTo(ContainSubstring("failed</span>"),
+				"failed pill must not appear when no failures")
+		})
+
+		It("is present with the correct count when failures exist", func() {
+			report := mocks.CreateMockProgressReport(s.FailedState, s.FailedState)
+			data := Data{StaticData: staticData(), Report: report}
+
+			out, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring("2 failed"), "pill must show the failure count")
+		})
+	})
+
+	Describe("all-clear state", func() {
+		It("renders a non-blank all-clear card in email-html when nothing in Failed/Updated/Stale", func() {
+			// Use mockReport with empty failed/updated/stale to simulate a quiet run.
+			report := &mockReport{}
+			data := Data{StaticData: staticData(), Report: report}
+
+			out, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).NotTo(BeEmpty(), "all-clear email must not be empty")
+			Expect(out).To(ContainSubstring("Everything is up to date"),
+				"all-clear card text must appear")
+		})
+
+		It("renders a non-blank all-clear message in email-text when nothing in Failed/Updated/Stale", func() {
+			report := &mockReport{}
+			data := Data{StaticData: staticData(), Report: report}
+
+			out, err := renderTextTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).NotTo(BeEmpty())
+			Expect(out).To(ContainSubstring("Everything is up to date"))
+		})
+	})
+
+	Describe("nil report (startup / out-of-cycle log)", func() {
+		// SendNotification(nil) is called on startup and for out-of-cycle logs.
+		// The nil-guard in the template must prevent template execution errors
+		// that would otherwise trigger the Fatal() path in sendEntries.
+
+		It("email-html renders without error when report is nil", func() {
+			entries := []*logrus.Entry{
+				{Message: "startup log message"},
+			}
+			data := Data{StaticData: staticData(), Entries: entries, Report: nil}
+
+			_, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("email-html renders empty string when both report and entries are nil", func() {
+			data := Data{StaticData: staticData(), Entries: nil, Report: nil}
+
+			out, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.TrimSpace(out)).To(BeEmpty(),
+				"no report, no entries → nothing to send")
+		})
+
+		It("email-text renders without error when report is nil", func() {
+			data := Data{StaticData: staticData(), Entries: []*logrus.Entry{{Message: "hello"}}, Report: nil}
+
+			_, err := renderTextTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("mixed state rendering", func() {
+		// Build a report directly with all three active buckets populated.
+		buildMixedReport := func() *mockReport {
+			failed := &injectableStatus{
+				name: "fail1", imageName: "mock/fail1:latest",
+				currentImageID: t.ImageID("sha256:ffff"),
+				latestImageID:  t.ImageID("sha256:ffff"),
+				errStr:         "restart failed",
+			}
+			updated := &injectableStatus{
+				name: "updt1", imageName: "mock/updt1:latest",
+				currentImageID: t.ImageID("sha256:aaaa"),
+				latestImageID:  t.ImageID("sha256:bbbb"),
+			}
+			stale := &injectableStatus{
+				name: "stale1", imageName: "mock/stale1:latest",
+				currentImageID: t.ImageID("sha256:cccc"),
+				latestImageID:  t.ImageID("sha256:dddd"),
+			}
+			return &mockReport{
+				failed:  []t.ContainerReport{failed},
+				updated: []t.ContainerReport{updated},
+				stale:   []t.ContainerReport{stale},
+			}
+		}
+
+		It("email-html renders failed, updated, and stale sections", func() {
+			data := Data{StaticData: staticData(), Report: buildMixedReport()}
+
+			out, err := renderHTMLTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring("FAILED"))
+			Expect(out).To(ContainSubstring("UPDATED"))
+			Expect(out).To(ContainSubstring("UPDATE AVAILABLE"))
+		})
+
+		It("email-text renders all sections", func() {
+			data := Data{StaticData: staticData(), Report: buildMixedReport()}
+
+			out, err := renderTextTemplate(data)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring("FAILED"))
+			Expect(out).To(ContainSubstring("UPDATED"))
+			Expect(out).To(ContainSubstring("UPDATE AVAILABLE -- MONITOR ONLY"))
+		})
+	})
+})

--- a/pkg/notifications/email_usehtml_test.go
+++ b/pkg/notifications/email_usehtml_test.go
@@ -1,0 +1,63 @@
+package notifications_test
+
+// Tests that UseHTML in the SMTP shoutrrr URL derives from the resolved
+// notification-template flag value, not the plaintext flag independently.
+
+import (
+	"github.com/Nitroxaddict/vigil/cmd"
+	"github.com/Nitroxaddict/vigil/internal/flags"
+	"github.com/Nitroxaddict/vigil/pkg/notifications"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("email notifier UseHTML flag wiring", func() {
+	// baseArgs are the minimum SMTP flags needed to build a valid URL.
+	baseArgs := func(extra ...string) []string {
+		args := []string{
+			"--notifications", "email",
+			"--notification-email-from", "from@example.com",
+			"--notification-email-to", "to@example.com",
+			"--notification-email-server", "mail.example.com",
+			"--notification-email-server-user", "user",
+			"--notification-email-server-password", "pass",
+		}
+		return append(args, extra...)
+	}
+
+	buildEmailURL := func(args []string) string {
+		command := cmd.NewRootCommand()
+		flags.RegisterNotificationFlags(command)
+		Expect(command.ParseFlags(args)).To(Succeed())
+		urls, _ := notifications.AppendLegacyUrls([]string{}, command)
+		Expect(urls).To(HaveLen(1))
+		return urls[0]
+	}
+
+	When("notification-template is explicitly set to email-html", func() {
+		It("sets UseHTML=Yes in the SMTP URL", func() {
+			args := baseArgs("--notification-template", "email-html")
+			url := buildEmailURL(args)
+			Expect(url).To(ContainSubstring("usehtml=Yes"),
+				"UseHTML must be true when template is email-html")
+		})
+	})
+
+	When("notification-template is explicitly set to email-text", func() {
+		It("does not set UseHTML=Yes in the SMTP URL", func() {
+			args := baseArgs("--notification-template", "email-text")
+			url := buildEmailURL(args)
+			Expect(url).NotTo(ContainSubstring("usehtml=Yes"),
+				"UseHTML must be false when template is email-text")
+		})
+	})
+
+	When("no notification-template is set (default)", func() {
+		It("does not set UseHTML=Yes in the SMTP URL", func() {
+			args := baseArgs()
+			url := buildEmailURL(args)
+			// Default template is not email-html, so UseHTML stays false.
+			Expect(url).NotTo(ContainSubstring("usehtml=Yes"))
+		})
+	})
+})

--- a/pkg/notifications/model.go
+++ b/pkg/notifications/model.go
@@ -1,6 +1,8 @@
 package notifications
 
 import (
+	"time"
+
 	t "github.com/Nitroxaddict/vigil/pkg/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -9,6 +11,7 @@ import (
 type StaticData struct {
 	Title string
 	Host  string
+	Time  time.Time
 }
 
 // Data is the notification template data model

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -138,6 +138,7 @@ func GetTemplateData(c *cobra.Command) StaticData {
 	return StaticData{
 		Host:  hostname,
 		Title: title,
+		Time:  time.Now(),
 	}
 }
 

--- a/pkg/notifications/preview/data/data.go
+++ b/pkg/notifications/preview/data/data.go
@@ -11,31 +11,33 @@ import (
 )
 
 type previewData struct {
+	staticData     // embedded: promotes Title, Host, Time to template scope
 	rand           *rand.Rand
 	lastTime       time.Time
 	report         *report
 	containerCount int
 	Entries        []*logEntry
-	StaticData     staticData
 }
 
 type staticData struct {
 	Title string
 	Host  string
+	Time  time.Time
 }
 
 // New initializes a new preview data struct
 func New() *previewData {
 	return &previewData{
+		staticData: staticData{
+			Title: "Title",
+			Host:  "Host",
+			Time:  time.Now(),
+		},
 		rand:           rand.New(rand.NewSource(1)),
 		lastTime:       time.Now().Add(-30 * time.Minute),
 		report:         nil,
 		containerCount: 0,
 		Entries:        []*logEntry{},
-		StaticData: staticData{
-			Title: "Title",
-			Host:  "Host",
-		},
 	}
 }
 

--- a/pkg/notifications/preview/data/status.go
+++ b/pkg/notifications/preview/data/status.go
@@ -28,6 +28,13 @@ func (u *containerStatus) LatestImageID() wt.ImageID {
 	return u.newImage
 }
 
+// LatestImageVersion returns the OCI version label for the latest image.
+// The preview data generator does not set version labels, so this always
+// returns "" (versionOrID will fall back to ShortID).
+func (u *containerStatus) LatestImageVersion() string {
+	return ""
+}
+
 func (u *containerStatus) ImageName() string {
 	return u.imageName
 }

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -2,6 +2,8 @@ package notifications
 
 import (
 	"bytes"
+	"fmt"
+	htmltemplate "html/template"
 	stdlog "log"
 	"os"
 	"strings"
@@ -33,6 +35,7 @@ type shoutrrrTypeNotifier struct {
 	entries        []*log.Entry
 	logLevel       log.Level
 	template       *template.Template
+	htmlTemplate   *htmltemplate.Template // non-nil only for the email-html template
 	messages       chan string
 	done           chan bool
 	legacyTemplate bool
@@ -78,9 +81,22 @@ func (n *shoutrrrTypeNotifier) AddLogHook() {
 }
 
 func createNotifier(urls []string, level log.Level, tplString string, legacy bool, data StaticData, stdout bool, delay time.Duration) *shoutrrrTypeNotifier {
-	tpl, err := getShoutrrrTemplate(tplString, legacy)
-	if err != nil {
-		log.Errorf("Could not use configured notification template: %s. Using default template", err)
+	var tpl *template.Template
+	var htmlTpl *htmltemplate.Template
+
+	if tplString == "email-html" {
+		var err error
+		htmlTpl, err = getShoutrrrHTMLTemplate()
+		if err != nil {
+			log.Errorf("Could not parse email-html template: %s. Falling back to default template", err)
+			tpl, _ = getShoutrrrTemplate("", legacy)
+		}
+	} else {
+		var err error
+		tpl, err = getShoutrrrTemplate(tplString, legacy)
+		if err != nil {
+			log.Errorf("Could not use configured notification template: %s. Using default template", err)
+		}
 	}
 
 	var logger types.StdLogger
@@ -106,6 +122,7 @@ func createNotifier(urls []string, level log.Level, tplString string, legacy boo
 		done:           make(chan bool),
 		logLevel:       level,
 		template:       tpl,
+		htmlTemplate:   htmlTpl,
 		legacyTemplate: legacy,
 		data:           data,
 		params:         params,
@@ -139,8 +156,14 @@ func (n *shoutrrrTypeNotifier) buildMessage(data Data) (string, error) {
 	if n.legacyTemplate {
 		templateData = data.Entries
 	}
-	if err := n.template.Execute(&body, templateData); err != nil {
-		return "", err
+	if n.htmlTemplate != nil {
+		if err := n.htmlTemplate.Execute(&body, templateData); err != nil {
+			return "", err
+		}
+	} else {
+		if err := n.template.Execute(&body, templateData); err != nil {
+			return "", err
+		}
 	}
 
 	return body.String(), nil
@@ -235,4 +258,17 @@ func getShoutrrrTemplate(tplString string, legacy bool) (tpl *template.Template,
 	}
 
 	return
+}
+
+// getShoutrrrHTMLTemplate parses the email-html common template using
+// html/template so that all container-metadata values are context-aware
+// HTML-escaped before being written into the message body.
+func getShoutrrrHTMLTemplate() (*htmltemplate.Template, error) {
+	tplContent, ok := commonTemplates["email-html"]
+	if !ok {
+		return nil, fmt.Errorf("email-html template not found in common templates")
+	}
+	return htmltemplate.New("").
+		Funcs(htmltemplate.FuncMap(templates.Funcs)).
+		Parse(tplContent)
 }

--- a/pkg/notifications/templates/funcs.go
+++ b/pkg/notifications/templates/funcs.go
@@ -6,15 +6,18 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Nitroxaddict/vigil/pkg/types"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
 
 var Funcs = template.FuncMap{
-	"ToUpper": strings.ToUpper,
-	"ToLower": strings.ToLower,
-	"ToJSON":  toJSON,
-	"Title":   cases.Title(language.AmericanEnglish).String,
+	"ToUpper":       strings.ToUpper,
+	"ToLower":       strings.ToLower,
+	"ToJSON":        toJSON,
+	"Title":         cases.Title(language.AmericanEnglish).String,
+	"versionOrID":   versionOrID,
+	"sanitizeField": sanitizeField,
 }
 
 func toJSON(v interface{}) string {
@@ -24,4 +27,26 @@ func toJSON(v interface{}) string {
 		return fmt.Sprintf("failed to marshal JSON in notification template: %v", err)
 	}
 	return string(bytes)
+}
+
+// versionOrID returns the OCI version label from the latest image when present,
+// otherwise the 12-char short ID of the latest image. Safe for both text and
+// html/template engines: the returned string is auto-escaped by html/template.
+func versionOrID(cr types.ContainerReport) string {
+	if v := cr.LatestImageVersion(); v != "" {
+		return v
+	}
+	return string(cr.LatestImageID().ShortID())
+}
+
+// sanitizeField strips ASCII control characters (< 0x20 and 0x7f) from s.
+// Used in the email-text template to prevent CR/LF from breaking the
+// line-oriented plain-text format.
+func sanitizeField(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
 }

--- a/pkg/session/container_status.go
+++ b/pkg/session/container_status.go
@@ -1,6 +1,10 @@
 package session
 
-import wt "github.com/Nitroxaddict/vigil/pkg/types"
+import (
+	"strings"
+
+	wt "github.com/Nitroxaddict/vigil/pkg/types"
+)
 
 // State indicates what the current state is of the container
 type State int
@@ -17,15 +21,34 @@ const (
 	StaleState
 )
 
+// maxLabelLen is the maximum number of bytes returned for any OCI label value.
+const maxLabelLen = 64
+
 // ContainerStatus contains the container state during a session
 type ContainerStatus struct {
-	containerID   wt.ContainerID
-	oldImage      wt.ImageID
-	newImage      wt.ImageID
-	containerName string
-	imageName     string
+	containerID    wt.ContainerID
+	oldImage       wt.ImageID
+	newImage       wt.ImageID
+	newImageLabels map[string]string
+	containerName  string
+	imageName      string
 	error
 	state State
+}
+
+// sanitizeLabel truncates s to maxLabelLen bytes and strips ASCII control
+// characters (bytes < 0x20 and 0x7f). It is applied to every OCI label value
+// before it is exposed to template engines.
+func sanitizeLabel(s string) string {
+	if len(s) > maxLabelLen {
+		s = s[:maxLabelLen]
+	}
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 // ID returns the container ID
@@ -46,6 +69,16 @@ func (u *ContainerStatus) CurrentImageID() wt.ImageID {
 // LatestImageID returns the newest image ID found during the session
 func (u *ContainerStatus) LatestImageID() wt.ImageID {
 	return u.newImage
+}
+
+// LatestImageVersion returns the value of the org.opencontainers.image.version
+// label from the newest image, sanitized and truncated. Returns "" when the
+// label is absent or the label map is nil.
+func (u *ContainerStatus) LatestImageVersion() string {
+	if u.newImageLabels == nil {
+		return ""
+	}
+	return sanitizeLabel(u.newImageLabels["org.opencontainers.image.version"])
 }
 
 // ImageName returns the name:tag that the container uses

--- a/pkg/session/container_status_test.go
+++ b/pkg/session/container_status_test.go
@@ -1,0 +1,75 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	wt "github.com/Nitroxaddict/vigil/pkg/types"
+)
+
+func makeStatusWithLabels(labels map[string]string) *ContainerStatus {
+	return &ContainerStatus{
+		containerID:    wt.ContainerID("abc123"),
+		newImage:       wt.ImageID("sha256:deadbeef1234"),
+		newImageLabels: labels,
+	}
+}
+
+func TestLatestImageVersion_absent(t *testing.T) {
+	s := makeStatusWithLabels(map[string]string{
+		"other.label": "v1.0",
+	})
+	assert.Equal(t, "", s.LatestImageVersion(), "absent OCI version label must return empty string")
+}
+
+func TestLatestImageVersion_nilLabels(t *testing.T) {
+	s := makeStatusWithLabels(nil)
+	require.NotPanics(t, func() {
+		v := s.LatestImageVersion()
+		assert.Equal(t, "", v, "nil label map must return empty string without panic")
+	})
+}
+
+func TestLatestImageVersion_present(t *testing.T) {
+	s := makeStatusWithLabels(map[string]string{
+		"org.opencontainers.image.version": "1.45.3",
+	})
+	assert.Equal(t, "1.45.3", s.LatestImageVersion())
+}
+
+func TestLatestImageVersion_truncatesLongLabel(t *testing.T) {
+	// 1 MB label value must be truncated to maxLabelLen bytes
+	big := strings.Repeat("a", 1024*1024)
+	s := makeStatusWithLabels(map[string]string{
+		"org.opencontainers.image.version": big,
+	})
+	v := s.LatestImageVersion()
+	assert.LessOrEqual(t, len(v), maxLabelLen, "label must be truncated to maxLabelLen bytes")
+}
+
+func TestLatestImageVersion_stripsControlChars(t *testing.T) {
+	// CR, LF, NUL are control characters; they must be stripped.
+	raw := "1.0\r\n\x00injection"
+	s := makeStatusWithLabels(map[string]string{
+		"org.opencontainers.image.version": raw,
+	})
+	v := s.LatestImageVersion()
+	assert.NotContains(t, v, "\r", "CR must be stripped from version label")
+	assert.NotContains(t, v, "\n", "LF must be stripped from version label")
+	assert.NotContains(t, v, "\x00", "NUL must be stripped from version label")
+	assert.Contains(t, v, "1.0", "printable content must be preserved")
+}
+
+func TestSanitizeLabel_truncatesExact(t *testing.T) {
+	// exactly maxLabelLen chars — no truncation
+	s := strings.Repeat("x", maxLabelLen)
+	assert.Equal(t, s, sanitizeLabel(s))
+
+	// maxLabelLen+1 — truncated
+	long := strings.Repeat("x", maxLabelLen+1)
+	result := sanitizeLabel(long)
+	assert.Equal(t, maxLabelLen, len(result))
+}

--- a/pkg/session/progress.go
+++ b/pkg/session/progress.go
@@ -8,27 +8,28 @@ import (
 type Progress map[types.ContainerID]*ContainerStatus
 
 // UpdateFromContainer sets various status fields from their corresponding container equivalents
-func UpdateFromContainer(cont types.Container, newImage types.ImageID, state State) *ContainerStatus {
+func UpdateFromContainer(cont types.Container, newImage types.ImageID, newImageLabels map[string]string, state State) *ContainerStatus {
 	return &ContainerStatus{
-		containerID:   cont.ID(),
-		containerName: cont.Name(),
-		imageName:     cont.ImageName(),
-		oldImage:      cont.SafeImageID(),
-		newImage:      newImage,
-		state:         state,
+		containerID:    cont.ID(),
+		containerName:  cont.Name(),
+		imageName:      cont.ImageName(),
+		oldImage:       cont.SafeImageID(),
+		newImage:       newImage,
+		newImageLabels: newImageLabels,
+		state:          state,
 	}
 }
 
 // AddSkipped adds a container to the Progress with the state set as skipped
 func (m Progress) AddSkipped(cont types.Container, err error) {
-	update := UpdateFromContainer(cont, cont.SafeImageID(), SkippedState)
+	update := UpdateFromContainer(cont, cont.SafeImageID(), nil, SkippedState)
 	update.error = err
 	m.Add(update)
 }
 
 // AddScanned adds a container to the Progress with the state set as scanned
-func (m Progress) AddScanned(cont types.Container, newImage types.ImageID) {
-	m.Add(UpdateFromContainer(cont, newImage, ScannedState))
+func (m Progress) AddScanned(cont types.Container, newImage types.ImageID, newImageLabels map[string]string) {
+	m.Add(UpdateFromContainer(cont, newImage, newImageLabels, ScannedState))
 }
 
 // UpdateFailed updates the containers passed, setting their state as failed with the supplied error

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -17,6 +17,7 @@ type ContainerReport interface {
 	Name() string
 	CurrentImageID() ImageID
 	LatestImageID() ImageID
+	LatestImageVersion() string
 	ImageName() string
 	Error() string
 	State() string


### PR DESCRIPTION
## Summary

Closes #29

Implements the full email notification redesign specified in #29 (original issue + two confirmed scope additions in comments):

- **`email-html`** — fully styled HTML email rendered via `html/template` (context-aware HTML escaping; XSS-safe against container/image metadata). Card-based layout with per-state sections (Failed/Updated/Stale), "N failed" pill, timestamp, and an explicit all-clear card when nothing changed.
- **`email-text`** — pipe-delimited plain-text fallback. Same all-clear handling and nil-guard.
- **`LatestImageVersion()`** — new method on `ContainerReport`; reads the `org.opencontainers.image.version` OCI label from the new image, sanitized (truncated to 64 chars, control chars stripped). `versionOrID` template function: version if present, else `ShortID()`.
- **Auto-default** — when `--notifications email` is the *sole* configured notifier (no `--notification-url` entries), `ProcessFlagAliases` defaults `notification-template` to `email-html` and forces `notification-report=true`. `--notification-email-plaintext` / `WATCHTOWER_NOTIFICATION_EMAIL_PLAINTEXT` opts into `email-text` instead.
- **`UseHTML`** in the SMTP shoutrrr URL derives from the resolved `notification-template` flag value, not the plaintext flag independently.
- **`StaticData.Time`** — `time.Time` field, populated with `time.Now()` in `GetTemplateData`, used for the timestamp in the HTML header.

### Security hardening (per security-critic review)

- `email-html` is the **only** template parsed and executed via `html/template`; all other templates continue to use `text/template`. Container names, image names, error strings, and OCI labels are context-aware escaped.
- `LatestImageVersion()` sanitizes at the data boundary (truncation + control-char stripping) before any template sees the value.
- `sanitizeField` template function strips control characters from `Error()`/`Name()`/`ImageName()` in the `email-text` path.
- Nil-guard `{{if .Report}}…{{else}}…{{end}}` in both templates prevents Fatal() crashes on startup `SendNotification(nil)` calls.
- No container metadata reaches the email Subject/headers; `Title` stays sourced from hostname/operator tag only.

## Test plan

- [x] `go test ./...` — all packages pass (no regressions)
- [x] HTML escaping regression: `<script>alert(1)</script>` and `"><img src=x onerror=alert(1)>` in container name, image name, OCI version label, and error string render as HTML entities — raw tags do not appear
- [x] Nil/missing version label falls back to `ShortID()` without panic or template error
- [x] All-clear card renders non-blank when nothing in Failed/Updated/Stale
- [x] "N failed" pill absent when no failures, present with correct count when failures exist
- [x] Startup `SendNotification(nil)` renders without error in both templates
- [x] 1MB label truncated to 64 bytes; label with `\r\n\x00` has control chars stripped
- [x] `UseHTML=Yes` in SMTP URL only when template is `email-html` (not `email-text`, not default)
- [x] Auto-default fires only when email is sole legacy notifier; not when multiple notifiers or `--notification-url` present; explicit `--notification-template` not overridden

🤖 Generated with [Claude Code](https://claude.com/claude-code)